### PR TITLE
docs: DocC Website Root 랜딩 페이지 추가

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,0 +1,300 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="한글 파일(.hwp)을 읽고 쓰기 위한 스위프트 패키지 Hwp-Swift 소개와 CoreHwp 문서 안내">
+  <title>Hwp-Swift — 한글 파일을 읽고 쓰기 위한 Swift 패키지</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f7f3ec;
+      --surface: #fffaf2;
+      --surface-muted: #eee6d9;
+      --text: #1d1a16;
+      --text-muted: #645b50;
+      --border: #ded2c0;
+      --primary: #245d4f;
+      --primary-text: #ffffff;
+      --primary-hover: #17483c;
+      --secondary-hover: #ebe1d2;
+      --accent: #bf6a30;
+      --focus: #d97706;
+      --shadow: 0 24px 70px rgba(79, 57, 34, 0.14);
+      --radius-lg: 28px;
+      --radius-md: 18px;
+      --radius-pill: 999px;
+      --space-1: 0.25rem;
+      --space-2: 0.5rem;
+      --space-3: 0.75rem;
+      --space-4: 1rem;
+      --space-5: 1.5rem;
+      --space-6: 2rem;
+      --space-7: 3rem;
+      --space-8: 4.5rem;
+      --max: 720px;
+      --font: -apple-system, BlinkMacSystemFont, "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+      --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #1e211f;
+        --surface: #282c29;
+        --surface-muted: #222622;
+        --text: #f4efe7;
+        --text-muted: #c9bfb1;
+        --border: #454139;
+        --primary: #8fd3bf;
+        --primary-text: #11231e;
+        --primary-hover: #a8dfcf;
+        --secondary-hover: #333832;
+        --accent: #f0a35f;
+        --focus: #f4b26b;
+        --shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      min-height: 100vh;
+      margin: 0;
+      background:
+        radial-gradient(circle at 18% 8%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 30rem),
+        radial-gradient(circle at 82% 18%, color-mix(in srgb, var(--primary) 18%, transparent), transparent 28rem),
+        linear-gradient(180deg, var(--bg), color-mix(in srgb, var(--bg) 88%, var(--surface-muted)));
+      color: var(--text);
+      font-family: var(--font);
+      line-height: 1.65;
+      text-rendering: optimizeLegibility;
+    }
+
+    body::before {
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      pointer-events: none;
+      content: "";
+      background-image:
+        linear-gradient(color-mix(in srgb, var(--text) 4%, transparent) 1px, transparent 1px),
+        linear-gradient(90deg, color-mix(in srgb, var(--text) 4%, transparent) 1px, transparent 1px);
+      background-size: 44px 44px;
+      mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.5), transparent 70%);
+    }
+
+    a {
+      color: inherit;
+      text-decoration-thickness: 0.08em;
+      text-underline-offset: 0.18em;
+    }
+
+    a:hover {
+      color: var(--primary-hover);
+    }
+
+    a:focus-visible {
+      outline: 3px solid var(--focus);
+      outline-offset: 4px;
+      border-radius: var(--space-2);
+    }
+
+    .page {
+      width: min(100% - 2rem, var(--max));
+      margin: 0 auto;
+      padding: var(--space-7) 0 var(--space-5);
+    }
+
+    .hero {
+      padding: var(--space-7) 0 var(--space-6);
+    }
+
+    h1,
+    h2,
+    p {
+      margin-top: 0;
+    }
+
+    h1 {
+      max-width: 14ch;
+      margin-bottom: var(--space-4);
+      font-size: clamp(3.3rem, 11vw, 6.2rem);
+      line-height: 0.96;
+      letter-spacing: 0.02em;
+    }
+
+    h2 {
+      margin-bottom: var(--space-3);
+      font-size: clamp(1.35rem, 3vw, 1.75rem);
+      line-height: 1.25;
+      letter-spacing: -0.035em;
+    }
+
+    .tagline {
+      max-width: 34rem;
+      margin-bottom: var(--space-6);
+      color: var(--text-muted);
+      font-size: clamp(1.125rem, 3vw, 1.45rem);
+      line-height: 1.55;
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-3);
+    }
+
+    .button {
+      display: inline-flex;
+      min-height: 3rem;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-pill);
+      padding: 0.82rem 1.15rem;
+      font-weight: 800;
+      line-height: 1;
+      text-decoration: none;
+      transition: transform 160ms ease, background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+    }
+
+    .button:hover {
+      transform: translateY(-2px);
+    }
+
+    .button-primary {
+      border-color: var(--primary);
+      background: var(--primary);
+      color: var(--primary-text);
+      box-shadow: 0 14px 34px color-mix(in srgb, var(--primary) 24%, transparent);
+    }
+
+    .button-primary:hover {
+      background: var(--primary-hover);
+      color: var(--primary-text);
+    }
+
+    .button-secondary {
+      background: color-mix(in srgb, var(--surface) 78%, transparent);
+      color: var(--text);
+    }
+
+    .button-secondary:hover {
+      background: var(--secondary-hover);
+      color: var(--text);
+    }
+
+    main {
+      display: grid;
+      gap: var(--space-5);
+    }
+
+    section {
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      background: color-mix(in srgb, var(--surface) 92%, transparent);
+      box-shadow: var(--shadow);
+      padding: clamp(1.25rem, 4vw, 2rem);
+    }
+
+    section p:last-child {
+      margin-bottom: 0;
+    }
+
+    .note {
+      color: var(--text-muted);
+    }
+
+    pre {
+      margin: var(--space-4) 0 0;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      background: var(--surface-muted);
+      padding: var(--space-4);
+      overflow-x: auto;
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 0.94rem;
+      line-height: 1.6;
+    }
+
+    code {
+      font-family: var(--mono);
+    }
+
+    footer {
+      padding: var(--space-6) 0 0;
+      color: var(--text-muted);
+      font-size: 0.95rem;
+      text-align: center;
+    }
+
+    @media (max-width: 520px) {
+      .page {
+        width: min(100% - 1.25rem, var(--max));
+        padding-top: var(--space-5);
+      }
+
+      .hero {
+        padding-top: var(--space-6);
+      }
+
+      .actions,
+      .button {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <h1>Hwp-Swift</h1>
+      <p class="tagline">한글 파일(.hwp)을 읽고 쓰기 위한 스위프트 패키지</p>
+      <nav class="actions" aria-label="주요 링크">
+        <a class="button button-primary" href="./documentation/corehwp/">CoreHwp 문서 보기 →</a>
+        <a class="button button-secondary" href="https://github.com/sboh1214/hwp-swift">GitHub</a>
+      </nav>
+    </header>
+
+    <main>
+      <section aria-labelledby="intro-title">
+        <h2 id="intro-title">소개</h2>
+        <p>한글 파일을 읽고 쓰기 위한 스위프트 패키지</p>
+        <p class="note">본 제품은 한글과컴퓨터의 한글 문서 파일(.hwp) 공개 문서를 참고하여 개발하였습니다.</p>
+        <p class="note">라이브러리 구조와 공개 형식은 CoreHwp 문서에서 확인할 수 있습니다.</p>
+      </section>
+
+      <section aria-labelledby="install-title">
+        <h2 id="install-title">설치</h2>
+        <p>Xcode에서 <code>File</code> &gt; <code>Swift Packages</code> &gt; <code>Add Package Dependency...</code> 메뉴를 선택하세요.</p>
+        <p>또는 의존성을 아래와 같이 수동으로 추가합니다.</p>
+        <pre><code>dependencies: [
+    .package(url: "https://github.com/sboh1214/hwp-swift.git", branch: "main"),
+],</code></pre>
+        <p class="note">안정 릴리스가 태깅되면 <code>branch: "main"</code> 대신 <code>from: "x.y.z"</code>로 고정하는 것을 권장합니다.</p>
+      </section>
+
+      <section aria-labelledby="contributing-title">
+        <h2 id="contributing-title">기여</h2>
+        <p><a href="https://github.com/sboh1214/hwp-swift/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a>를 방문하세요.</p>
+      </section>
+
+      <section aria-labelledby="license-title">
+        <h2 id="license-title">라이센스</h2>
+        <p>본 라이브러리는 <a href="https://github.com/sboh1214/hwp-swift/blob/main/LICENSE">LGPL 라이센스</a>를 따릅니다.</p>
+      </section>
+    </main>
+
+    <footer>
+      <p>© Hwp-Swift · LGPL</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,6 +38,8 @@ jobs:
             --transform-for-static-hosting \
             --hosting-base-path hwp-swift \
             --output-path ./docs
+      - name: Overlay landing page
+        run: cp .github/pages/index.html ./docs/index.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ Package.resolved
 
 # AI generated files
 /.omo/
+/.playwright-mcp/

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ Package.resolved
 # macOS
 .DS_Store
 
+# DocC build artifacts
+/docs/
+
 # AI generated files
 /.omo/
 /.playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # 프로젝트 지식 베이스
 
-**Commit:** 8ecd926
-**Branch:** chore@actions-deps
+**Commit:** ca79c1a
+**Branch:** docs@landing-page
 
 ## 개요
 
@@ -16,7 +16,8 @@ hwp-swift/
 ├── Sources/CoreHwp/       # 라이브러리 (81 .swift files, ~4250 LOC)
 ├── Tests/CoreHwpTests/    # XCTest + Nimble + .hwp 픽스처
 ├── Package.swift          # swift-tools-version:5.9
-└── .github/workflows/     # Test-{macOS,Linux}, Coverage, Lint, Docs, PR
+├── .github/workflows/     # ci.yml (test+lint+coverage), cd.yml (DocC+release-drafter)
+└── .github/pages/         # cd.yml이 ./docs/index.html에 overlay하는 DocC 사이트 루트 랜딩 페이지
 ```
 
 폴더명은 **공백을 포함한 PascalCase** (예: `Ctrl Header/`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,46 @@ SwiftFormat과 SwiftLint는 모든 PR에서 CI(`ci.yml`의 `lint` 잡)으로 확
 
 커버리지는 [Codecov](https://codecov.io/gh/sboh1214/hwp-swift)에서 추적합니다.
 
+## 문서
+
+문서는 [Swift-DocC](https://www.swift.org/documentation/docc/)로 빌드되며,
+`main` 브랜치에 푸시될 때 [GitHub Pages](https://sboh1214.github.io/hwp-swift/)에
+배포됩니다. 배포 파이프라인은 `.github/workflows/cd.yml`을 참고하세요.
+
+### 로컬에서 미리보기
+
+DocC 미리보기 서버를 실행하면 변경 사항이 브라우저에 즉시 반영됩니다.
+
+```sh
+swift package --disable-sandbox preview-documentation --target CoreHwp
+```
+
+명령을 실행하면 `http://localhost:8080/documentation/corehwp` 같은 URL이
+콘솔에 표시되며, 그 주소를 브라우저에서 열면 됩니다.
+
+### 배포본과 동일한 정적 사이트 생성
+
+GitHub Pages에 배포되는 결과물 그대로 확인하고 싶다면 정적 사이트를 직접
+생성한 뒤 로컬 HTTP 서버로 띄웁니다. 루트 랜딩 페이지(`/hwp-swift/`)는
+DocC 생성 후 `.github/pages/index.html`로 덮어쓰는 구조이므로, 마지막 두
+단계로 이를 재현합니다.
+
+```sh
+rm -rf ./docs
+swift package --allow-writing-to-directory ./docs \
+  generate-documentation --target CoreHwp \
+  --disable-indexing \
+  --transform-for-static-hosting \
+  --hosting-base-path hwp-swift \
+  --output-path ./docs
+cp .github/pages/index.html ./docs/index.html
+python3 -m http.server 8000 --directory .
+```
+
+이후 `http://localhost:8000/hwp-swift/`에서 랜딩 페이지를,
+`http://localhost:8000/hwp-swift/documentation/corehwp/`에서 모듈 문서를
+확인할 수 있습니다.
+
 ## 배포
 
 ### Swift 버전이 새로 출시된 경우

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,15 @@ swift package --disable-sandbox preview-documentation --target CoreHwp
 ### 배포본과 동일한 정적 사이트 생성
 
 GitHub Pages에 배포되는 결과물 그대로 확인하고 싶다면 정적 사이트를 직접
-생성한 뒤 로컬 HTTP 서버로 띄웁니다. 루트 랜딩 페이지(`/hwp-swift/`)는
-DocC 생성 후 `.github/pages/index.html`로 덮어쓰는 구조이므로, 마지막 두
-단계로 이를 재현합니다.
+생성한 뒤 로컬 HTTP 서버로 띄웁니다. 출력 위치(`./docs`)와 인자는
+`cd.yml`의 `docs` job과 동일하며, 마지막의 랜딩 페이지 overlay까지 같은
+순서로 재현합니다. `./docs`는 `.gitignore`에 포함되어 있어 작업 후
+별도로 정리하지 않아도 됩니다.
+
+`--hosting-base-path hwp-swift`로 DocC 내부 자산이 `/hwp-swift/...`
+절대 경로로 굳어지므로, 로컬에서도 같은 URL 프리픽스가 필요합니다.
+임시 디렉터리에 심볼릭 링크를 두어 repo는 깨끗하게 유지하면서 그
+프리픽스만 만들어 줍니다.
 
 ```sh
 rm -rf ./docs
@@ -55,7 +61,10 @@ swift package --allow-writing-to-directory ./docs \
   --hosting-base-path hwp-swift \
   --output-path ./docs
 cp .github/pages/index.html ./docs/index.html
-python3 -m http.server 8000 --directory .
+
+rm -rf /tmp/hwp-preview && mkdir -p /tmp/hwp-preview
+ln -s "$(pwd)/docs" /tmp/hwp-preview/hwp-swift
+python3 -m http.server 8000 --directory /tmp/hwp-preview
 ```
 
 이후 `http://localhost:8000/hwp-swift/`에서 랜딩 페이지를,


### PR DESCRIPTION
## 요약

`https://sboh1214.github.io/hwp-swift/` 루트에서 DocC 렌더러가 *"The page you're looking for can't be found."*를 띄우던 문제 해결. GitHub Pages 404가 아니라 **DocC 내부 404**로, 토픽 루트가 `/documentation/corehwp`이고 `/`에 대응하는 토픽이 없어서 발생. DocC가 생성한 루트 `index.html`을 정적 랜딩 페이지로 덮어쓰는 방식으로 처리.

## 변경 사항

### 랜딩 페이지 + 배포 파이프라인

- `fc5f227` **docs: add landing page for DocC site root**
  - `.github/pages/index.html` 신규: self-contained (외부 리소스·스크립트 없음), `prefers-color-scheme` 라이트/다크, 한국어, 반응형. 4개 섹션(소개·설치·기여·라이센스)은 README.md 문구를 그대로 유지하고, 1차 CTA `CoreHwp 문서 보기 →`가 **상대 경로** `./documentation/corehwp/`로 연결돼 Pages 배포 시 `/hwp-swift/documentation/corehwp/`, 로컬에서도 동일 위치로 해석됨.
  - `cd.yml`의 `docs` job에 `Overlay landing page` 단계 추가 — `swift package generate-documentation` 직후 `cp .github/pages/index.html ./docs/index.html`로 DocC 루트 `index.html`을 덮어쓴 뒤 그대로 Pages 아티팩트로 업로드. `/documentation/corehwp/` 하위는 DocC가 만든 그대로 보존.
  - `CONTRIBUTING.md`에 \"문서\" 섹션 신설. (1) `swift package preview-documentation`을 통한 라이브 미리보기, (2) 배포본과 동일하게 `--transform-for-static-hosting` + 랜딩 페이지 오버레이 + `python3 -m http.server`로 정적 사이트를 재현하는 절차.

### 기타

- `3157438` **chore: ignore .playwright-mcp artifacts** — 브라우저 검증 시 playwright MCP가 repo 루트에 떨어뜨리는 스냅샷·콘솔 로그 디렉터리(`/.playwright-mcp/`)를 `.gitignore`에 추가.

## 검증

- `python3 -m http.server`로 `/hwp-swift/` 경로에 정적 호스팅 흉내 → Playwright(Chromium)로 로드해 다음 확인:
  - `<title>`, 시맨틱 랜드마크(`banner`/`main`/`region`/`contentinfo`), 한 개의 `<h1>`, `/url` 속성 모두 정상.
  - 한국어 글리프 정상 렌더(tofu 없음), 라이트 테마에서 대비·여백 OK.
  - 콘솔 에러는 `/favicon.ico` 404 하나뿐 (favicon은 의도적으로 두지 않음).
  - 1차 CTA의 `href`가 `./documentation/corehwp/`로 그대로 유지됨 (Pages·로컬 모두 호환).
- 실제 `swift package generate-documentation` 실행은 이 PR에서는 검증하지 않음 — 기존 CD가 이미 같은 명령을 실행 중이고, 추가된 한 줄 `cp`만 검증 대상이므로 GitHub Actions에서 처음 확인됨.

## 후속 작업 (이 PR 범위 외)

- README에 배포된 DocC 사이트 링크(`https://sboh1214.github.io/hwp-swift/`) 추가.
- 랜딩 페이지에서 모듈 외 추가 컨텐츠(릴리스 노트·예제 등) 노출 여부 결정.

## Screenshots

<img width="1129" height="810" alt="스크린샷 2026-06-14 오후 12 24 31" src="https://github.com/user-attachments/assets/d4bdc8ff-1f5f-4468-93f0-dfe9c8af646f" />

