### PR TITLE
 HwpPageLayer DrawnLine 캐시로 re-draw 시 재조판 제거

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # 프로젝트 지식 베이스
 
-**Branch:** feat/hwpkit-viewer
+**Branch:** perf/page-layer-drawn-line-cache
 
 ## 개요
 
@@ -147,6 +147,11 @@ pre-commit install && pre-commit run --all     # hook 설치 + 전체 실행
 성능 게이트: CI는 스모크 파라미터만 상시 실행 (공유 러너 wall-time 하드
 게이트는 flaky). 타이트 임계는 로컬 `HWP_PERF=1`로 확인 — 성능에 닿는
 PR은 실측 수치를 커밋 메시지에 기록한다.
+
+렌더 경로 최적화(캐시 도입 등)는 **속도는 실측, 등가성은 해시**로 나눠
+증명한다: 같은 문서를 최적화 무력화 A/B로 N회 재드로해 배수를 재고, 같은
+PR에서 픽셀 해시가 **양 폰트 모드 모두 무변화**임을 함께 보인다 (예:
+`HwpPageLayer` 줄 배치 캐시 1.85x/1.53x — `Sources/HwpKitNative/AGENTS.md`).
 
 ## 리뷰 대응 체크리스트 (렌더 회귀 방지)
 

--- a/Sources/HwpKitCore/AGENTS.md
+++ b/Sources/HwpKitCore/AGENTS.md
@@ -150,7 +150,7 @@ CT 측정보다 우선한다 — 폰트 대체로 줄 수가 부풀어 배치가
 
 ## Paint list
 
-- `HwpPaintCommand` = `@unchecked Sendable` enum. CF/NS 참조 타입을 담기 때문에 자동 Sendable 불가. enum case는 가로챌 init이 없어 **소유권 경계에서 동결**한다 — `HwpLaidOutParagraph.init`이 `NSAttributedString`을, `HwpShapeGeometry.init`이 `CGPath`를 복사본으로 저장한다 (mutable 서브클래스를 그대로 retain하면 Hashable 불변성·actor 경계 안전성이 깨진다). 새 참조 타입 payload를 추가하면 그 생산 지점에서 같은 복사를 해야 한다
+- `HwpPaintCommand` = `@unchecked Sendable` enum. CF/NS 참조 타입을 담기 때문에 자동 Sendable 불가. enum case는 가로챌 init이 없어 **소유권 경계에서 동결**한다 — `HwpLaidOutParagraph.init`이 `NSAttributedString`을, `HwpShapeGeometry.init`이 `CGPath`를 복사본으로 저장한다 (mutable 서브클래스를 그대로 retain하면 Hashable 불변성·actor 경계 안전성이 깨진다). 새 참조 타입 payload를 추가하면 그 생산 지점에서 같은 복사를 해야 한다. 소유권 경계를 거치지 않고 **painter가 `.drawText`를 직접 만드는 경로도 마찬가지** — `HwpMemoPanelPainter`는 헤더를 `NSMutableAttributedString`으로 조립한 뒤 `NSAttributedString(attributedString:)`로 동결해 싣는다. 이제 actor 안전성 말고 **소비자**도 생겼다: HwpKitNative의 줄 배치 캐시가 문자열 신원 (`===`)으로 조판 결과를 재사용하므로 "신원이 같으면 내용도 같다"가 전 생산 경로에서 성립해야 한다 (깨지면 조용한 오조판)
 - 케이스: `fillRect` / `strokeRect` / `drawText` / `drawPath` / `drawImage` / `drawImageReference(binItemId:rect:)` / `drawPlaceholder` / `hyperlink`
 - `drawImageReference` 는 비트맵을 운반하지 않는다 — HwpKitNative 의 `HwpPageImageProvider` 가 `HwpImageStore` + `HwpImageCache` + `HwpImageAdapter` 로 지연 디코딩
 - **`HwpPage.==` / `hash` 는 `paintList.commands.count` 만 비교** (structural fingerprint). 렌더 결과 비교용으로 쓰지 말 것

--- a/Sources/HwpKitCore/Paint/HwpMemoPanelPainter.swift
+++ b/Sources/HwpKitCore/Paint/HwpMemoPanelPainter.swift
@@ -131,7 +131,10 @@ public enum HwpMemoPanelPainter {
             ))
         }
         commands.append(.drawText(
-            attributedString: trailingText,
+            // 동결 — paint 명령의 immutable 계약 (HwpPaintCommand)을 지키는 유일한
+            // 누락 지점이었다. 렌더 캐시가 문자열 신원으로 조판 결과를 재사용하므로
+            // 신원이 같으면 내용도 같아야 한다.
+            attributedString: NSAttributedString(attributedString: trailingText),
             origin: CGPoint(
                 x: frame.maxX - balloonPadding - trailingWidth,
                 y: baselineTop

--- a/Sources/HwpKitNative/AGENTS.md
+++ b/Sources/HwpKitNative/AGENTS.md
@@ -55,13 +55,16 @@ macOS 페이지 레이어는 `HwpFlippedContentView` (isFlipped=true, NSScrollVi
 
 ## 줄 배치 캐시 (HwpPageLayer)
 
-`.drawText` 조판 결과 (`HwpDrawnTextLayout.lines`) 를 레이어 인스턴스 안에 캐시한다 — 재드로마다 framesetter 를 다시 돌리지 않는다. 재드로는 흔하다: contentsScale 변경 (핀치 줌 종료·Retina), bounds 변경 (`needsDisplayOnBoundsChange`), 이미지 디코딩 완료·디퍼드 용량 확보 콜백. 줄 기하는 pt 단위라 이 중 **어느 것도 캐시를 무효화하지 않는다** — 그게 이 캐시의 요점이다.
+`.drawText` 조판 결과 (`HwpDrawnTextLayout.lines`) 를 레이어 인스턴스 안에 캐시한다 — 재드로마다 framesetter 를 다시 돌리지 않는다. 재드로는 흔하다: contentsScale 변경 (핀치 줌 종료·Retina), bounds 변경 (`needsDisplayOnBoundsChange`), 이미지 디코딩 완료·디퍼드 용량 확보 콜백. 줄 기하는 pt 단위라 이 중 **어느 것도 캐시를 무효화하지 않는다** — 그게 이 캐시의 요점이다. `drawText` 는 조회 (`cachedDrawnLines`) · 순수 조판 (`typesetLines`) · 렌더 (`drawTextLines`) 셋으로 쪼개져 있어, 배치가 `pageHeight`·`bounds`·`contentsScale` 과 무관하다는 사실이 구조로 드러난다.
 
 - **키는 `paintList.commands` 의 인덱스**다. NSAttributedString 의 `ObjectIdentifier` 를 쓰면 안 된다: `drawPlaceholder` 가 draw 마다 임시 문자열을 만들어, 해제된 주소가 재사용되면 같은 rect 의 플레이스홀더끼리 엉뚱한 히트로 **조용한 오조판**이 난다. 인덱스 키는 `drawPlaceholder` 가 커맨드 인덱스를 갖지 않으므로 캐시 우회를 코드가 아니라 구조로 강제한다.
 - **무효화는 `paintList` didSet 의 `removeAll()`**, 그리고 히트 시 페이로드 재검증 (`===` + origin/lineWidth) 이 2차 방어선이다. 후자가 필요한 이유: `init(layer:)` 의 대입은 `super.init` 이전이라 didSet 이 발화하지 않고, 프로그레시브 갱신 경로는 양쪽 뷰의 `paintList == nil` 가드 때문에 기존 레이어에 재대입하지 않는다.
 - **CA 사본 (`init(layer:)`) 은 캐시를 복사하지 않는다** — 빈 캐시로 시작해 스스로 채운다.
-- **상한 초과 시 축출이 아니라 삽입 중단**이다. draw 는 커맨드를 항상 같은 순서로 전량 훑으므로 FIFO 축출은 워킹셋이 상한보다 큰 페이지에서 히트율 0% + 매 draw 전량 재삽입이 된다. 상한은 엔트리 수가 아니라 누적 줄 수 (엔트리 하나가 `maximumLineFrames` = 100,000 줄까지 담을 수 있다).
+- **상한 초과 시 축출이 아니라 삽입 중단**이다. draw 는 커맨드를 항상 같은 순서로 전량 훑으므로 FIFO 축출은 워킹셋이 상한보다 큰 페이지에서 히트율 0% + 매 draw 전량 재삽입이 된다. 상한은 엔트리 수가 아니라 누적 줄 수 (`cachedLineBudget` 기본 8,192 — 엔트리 하나가 `maximumLineFrames` = 100,000 줄까지 담을 수 있어 엔트리 수 상한은 CTLine 보유량을 못 묶는다). 인스턴스 프로퍼티라 테스트가 값을 낮춰 초과 경로를 작은 문서로 재현한다.
+- **락 (`NSLock`) 은 딕셔너리 조회/저장 순간에만 잡는다** — CoreText 조판·CTLineDraw 중에는 보유 금지 (그 아래로 텍스트 호출이 추가돼도 재진입 데드락이 없게). `paintList` didSet 의 `setNeedsDisplay()` 도 락 밖이다. 이 락은 Dictionary 동시 변형이라는 메모리 비안전만 막을 뿐 레이어를 thread-safe 하게 만들지 않는다 (클래스가 `@unchecked Sendable`).
 - 텍스트 선택의 `HwpSelectionGeometry` 도 같은 `[HwpDrawnLine]` 을 캐시하지만 **문서 스코프 + FIFO 512** 로 별개다 (그쪽은 랜덤 액세스라 FIFO 가 맞는다). 두 캐시는 서로 독립이다.
+- 회귀 가드는 `Tests/HwpKitNativeTests/HwpPageLayerCacheTests.swift` (7종). **기존 뷰 테스트는 전부 draw 1회라 콜드 경로만 타서 캐시 버그를 잡지 못한다** — 캐시를 건드리면 draw 를 2회 이상 돌리고 `typesetCount` / `cachedDrawnLineEntryCount` (테스트 전용 관측점) 로 단언할 것.
+- 실측 (macOS, 재드로 20회, 캐시 무력화 A/B): Column 1쪽 681.0 → 368.9ms (1.85x, 조판 220 → 0회), noori 3쪽 913.9 → 596.4ms (1.53x, 1360 → 80회 — 잔여 80 = 플레이스홀더 4개 × 20회로 설계대로 우회). 남는 시간은 CTLineDraw·장식이라 캐시가 줄일 몫이 아니고, 레이어가 객체째 폐기·재생성되는 스크롤은 콜드 경로라 이득이 없다.
 
 ## HwpDocumentActor.buildDocument
 

--- a/Sources/HwpKitNative/AGENTS.md
+++ b/Sources/HwpKitNative/AGENTS.md
@@ -47,11 +47,21 @@ HwpKitNative/
 
 macOS 페이지 레이어는 `HwpFlippedContentView` (isFlipped=true, NSScrollView documentView) 에 붙는다. NSClipView 는 documentView 의 flippedness 를 미러링하지만, `contentsAreFlipped()` 런타임 가드가 조상 flip 홀짝 변화를 동적으로 보정하므로 안전하다.
 
-`drawText` 의 CT flip (`translateBy` + `scaleBy(x: 1, y: -1)`) 과 `drawFlippedImage` 는 top-down 정규화 이후를 전제로 하므로 그대로 유지.
+`drawTextLines` 의 CT flip (`translateBy` + `scaleBy(x: 1, y: -1)`) 과 `drawFlippedImage` 는 top-down 정규화 이후를 전제로 하므로 그대로 유지.
 
 ## CRITICAL — contentsScale (Retina 선명도)
 
 `CALayer.contentsScale` 기본값은 1.0 — 설정하지 않으면 Retina 에서 1x 래스터를 확대해 **글씨가 흐릿해진다** (실제로 겪은 버그). 두 뷰 모두 `effectiveContentsScale` (backing/screen scale × max(1, zoom), 상한 4× — 산식은 `HwpDocumentViewSupport.effectiveContentsScale`) 을 레이어 생성 시와 zoom/backing 변경 시 적용한다 (macOS: `viewDidChangeBackingProperties`, iOS: `didMoveToWindow` + `scrollViewDidEndZooming`). 일괄 갱신은 `HwpDocumentViewSupport.updateContentsScale` — 메모 패널 레이어도 페이지와 함께 재래스터한다 (macOS·iOS 통일됨).
+
+## 줄 배치 캐시 (HwpPageLayer)
+
+`.drawText` 조판 결과 (`HwpDrawnTextLayout.lines`) 를 레이어 인스턴스 안에 캐시한다 — 재드로마다 framesetter 를 다시 돌리지 않는다. 재드로는 흔하다: contentsScale 변경 (핀치 줌 종료·Retina), bounds 변경 (`needsDisplayOnBoundsChange`), 이미지 디코딩 완료·디퍼드 용량 확보 콜백. 줄 기하는 pt 단위라 이 중 **어느 것도 캐시를 무효화하지 않는다** — 그게 이 캐시의 요점이다.
+
+- **키는 `paintList.commands` 의 인덱스**다. NSAttributedString 의 `ObjectIdentifier` 를 쓰면 안 된다: `drawPlaceholder` 가 draw 마다 임시 문자열을 만들어, 해제된 주소가 재사용되면 같은 rect 의 플레이스홀더끼리 엉뚱한 히트로 **조용한 오조판**이 난다. 인덱스 키는 `drawPlaceholder` 가 커맨드 인덱스를 갖지 않으므로 캐시 우회를 코드가 아니라 구조로 강제한다.
+- **무효화는 `paintList` didSet 의 `removeAll()`**, 그리고 히트 시 페이로드 재검증 (`===` + origin/lineWidth) 이 2차 방어선이다. 후자가 필요한 이유: `init(layer:)` 의 대입은 `super.init` 이전이라 didSet 이 발화하지 않고, 프로그레시브 갱신 경로는 양쪽 뷰의 `paintList == nil` 가드 때문에 기존 레이어에 재대입하지 않는다.
+- **CA 사본 (`init(layer:)`) 은 캐시를 복사하지 않는다** — 빈 캐시로 시작해 스스로 채운다.
+- **상한 초과 시 축출이 아니라 삽입 중단**이다. draw 는 커맨드를 항상 같은 순서로 전량 훑으므로 FIFO 축출은 워킹셋이 상한보다 큰 페이지에서 히트율 0% + 매 draw 전량 재삽입이 된다. 상한은 엔트리 수가 아니라 누적 줄 수 (엔트리 하나가 `maximumLineFrames` = 100,000 줄까지 담을 수 있다).
+- 텍스트 선택의 `HwpSelectionGeometry` 도 같은 `[HwpDrawnLine]` 을 캐시하지만 **문서 스코프 + FIFO 512** 로 별개다 (그쪽은 랜덤 액세스라 FIFO 가 맞는다). 두 캐시는 서로 독립이다.
 
 ## HwpDocumentActor.buildDocument
 

--- a/Sources/HwpKitNative/Rendering/HwpPageLayer.swift
+++ b/Sources/HwpKitNative/Rendering/HwpPageLayer.swift
@@ -7,6 +7,14 @@ import QuartzCore
 public final class HwpPageLayer: CALayer, @unchecked Sendable {
     public var paintList: HwpPaintList? {
         didSet {
+            // 캐시 키가 커맨드 인덱스라 paintList가 바뀌면 전량 무효다. 엔트리
+            // 재검증이 2차 방어선이라 이게 새도 오조판은 나지 않지만, 스테일
+            // CTLine이 상주하는 것을 막는다 (메모리 위생).
+            drawnLineCacheLock.lock()
+            drawnLineCache.removeAll()
+            cachedLineCount = 0
+            drawnLineCacheLock.unlock()
+            // 락 밖에서 — CA 콜백이 재진입해 같은 락을 다시 잡을 여지를 없앤다
             setNeedsDisplay()
         }
     }
@@ -21,6 +29,70 @@ public final class HwpPageLayer: CALayer, @unchecked Sendable {
         }
     }
 
+    // MARK: - 줄 배치 캐시
+
+    /// 조판 결과 1건. `attributedString`을 strong으로 들고 있어 캐시가 사는 동안
+    /// 그 객체 주소가 다른 문자열에 재사용될 수 없다 (`===` 재검증의 전제).
+    private struct DrawnLineEntry {
+        let attributedString: NSAttributedString
+        let origin: CGPoint
+        let lineWidth: CGFloat
+        let lines: [HwpDrawnLine]
+    }
+
+    /// `.drawText` 재조판 캐시 — 키는 `paintList.commands`의 인덱스다.
+    ///
+    /// NSAttributedString의 `ObjectIdentifier`를 키로 쓰지 않는다: `drawPlaceholder`가
+    /// draw마다 임시 문자열을 만들어 해제된 주소가 재사용되면 rect가 같은
+    /// 플레이스홀더끼리 origin·lineWidth까지 일치해 **엉뚱한 히트로 조용한 오조판**이
+    /// 난다. 커맨드 인덱스는 `drawPlaceholder`가 가질 수 없어 캐시 우회가 코드가
+    /// 아니라 구조로 강제된다. `HwpPaintCommand`도 같은 이유로 identity 해싱을
+    /// 의미상 틀린 것으로 배제해 뒀고, 값 타입 키는 `HwpSelectionGeometry.UnitKey`와
+    /// 같은 선례다.
+    ///
+    /// 락은 딕셔너리 조회/저장 순간에만 잡는다 — CoreText 조판이나 CTLineDraw 중에는
+    /// 절대 보유하지 않는다 (장래에 그 아래로 텍스트 호출이 추가돼도 재진입
+    /// 데드락이 나지 않게). 이 락은 Dictionary 동시 변형이라는 메모리 비안전만
+    /// 막을 뿐 레이어를 thread-safe하게 만들지 않는다: 클래스가 `@unchecked Sendable`
+    /// 이라 컴파일러가 동시 사용을 막지 않고, 테스트는 임의 스레드에서
+    /// `draw(in:)`을 직접 부른다.
+    private let drawnLineCacheLock = NSLock()
+    private var drawnLineCache: [Int: DrawnLineEntry] = [:]
+    private var cachedLineCount = 0
+    private var typesetCallCount = 0
+
+    /// 레이어당 캐시가 보유할 CTLine 총량 상한 (기본값).
+    ///
+    /// 초과 시 축출하지 않고 신규 삽입만 멈춘다 — draw는 커맨드를 항상 같은 순서로
+    /// 전량 훑으므로 FIFO 축출은 워킹셋이 상한보다 큰 페이지에서 히트율 0% + 매 draw
+    /// 전량 축출/재삽입이 된다 (`HwpSelectionGeometry`의 FIFO가 맞는 건 그쪽이 랜덤
+    /// 액세스라서다). 엔트리 수가 아니라 줄 수로 잡는 이유: 엔트리 하나가
+    /// `HwpParagraphLayout.maximumLineFrames`(=100,000) 줄까지 담을 수 있어 엔트리 수
+    /// 상한은 CTLine 보유량을 전혀 묶지 못한다. 실문서는 페이지당 수십 줄이라
+    /// 정상 문서는 걸리지 않고, 병적 대형 표·메모 풍선 다발만 막힌다.
+    private static let defaultCachedLineBudget = 8192
+
+    /// 인스턴스 상한 (기본 = 전역 상한) — 테스트가 예산 초과 경로를 작은 문서로
+    /// 재현할 수 있게 재정의를 허용한다.
+    var cachedLineBudget = HwpPageLayer.defaultCachedLineBudget
+
+    /// `HwpDrawnTextLayout.lines` 실제 호출 횟수 — 캐시가 재조판을 실제로 없애는지,
+    /// 플레이스홀더가 캐시를 우회하는지 테스트가 관측하는 지점
+    /// (`HwpFontResolver.matchCounter`와 같은 계측 관례). static이 아니라 인스턴스인
+    /// 이유: 레이어가 여럿 동시에 그려져 static 카운터는 테스트를 순서 의존으로 만든다.
+    var typesetCount: Int {
+        drawnLineCacheLock.lock()
+        defer { drawnLineCacheLock.unlock() }
+        return typesetCallCount
+    }
+
+    /// 캐시 엔트리 수 — 플레이스홀더 우회를 직접 단언하기 위한 관측 지점.
+    var cachedDrawnLineEntryCount: Int {
+        drawnLineCacheLock.lock()
+        defer { drawnLineCacheLock.unlock() }
+        return drawnLineCache.count
+    }
+
     override public init() {
         super.init()
         needsDisplayOnBoundsChange = true
@@ -28,6 +100,9 @@ public final class HwpPageLayer: CALayer, @unchecked Sendable {
 
     override public init(layer: Any) {
         if let layer = layer as? HwpPageLayer {
+            // 줄 배치 캐시는 복사하지 않는다 — 사본은 빈 캐시로 시작한다. (이 대입은
+            // super.init 이전이라 didSet이 발화하지 않고, 사본은 같은 paintList를
+            // 공유하므로 스스로 다시 채우면 정확하다.)
             paintList = layer.paintList
             pageHeight = layer.pageHeight
             imageProvider = layer.imageProvider
@@ -68,12 +143,12 @@ public final class HwpPageLayer: CALayer, @unchecked Sendable {
             }
         #endif
 
-        for command in paintList.commands {
-            execute(command, in: ctx)
+        for (index, command) in paintList.commands.enumerated() {
+            execute(command, at: index, in: ctx)
         }
     }
 
-    private func execute(_ command: HwpPaintCommand, in ctx: CGContext) {
+    private func execute(_ command: HwpPaintCommand, at commandIndex: Int, in ctx: CGContext) {
         switch command {
         case let .fillRect(rect, color):
             ctx.setFillColor(color)
@@ -85,7 +160,15 @@ public final class HwpPageLayer: CALayer, @unchecked Sendable {
             ctx.stroke(rect)
 
         case let .drawText(attributedString, origin, lineWidth):
-            drawText(attributedString, origin: origin, lineWidth: lineWidth, in: ctx)
+            drawTextLines(
+                cachedDrawnLines(
+                    commandIndex: commandIndex,
+                    attributedString: attributedString,
+                    origin: origin,
+                    lineWidth: lineWidth
+                ),
+                in: ctx
+            )
 
         case let .drawPath(path, fill, stroke, strokeWidth):
             drawPath(path, fill: fill, stroke: stroke, strokeWidth: strokeWidth, in: ctx)
@@ -106,20 +189,76 @@ public final class HwpPageLayer: CALayer, @unchecked Sendable {
         }
     }
 
-    /// 줄 배치는 `HwpDrawnTextLayout` (렌더·텍스트 선택 공유 — slight-overflow
-    /// 단일 줄, 양쪽 정렬 재조판, baselineLift 포함)이 계산하고, 여기서는
-    /// top-down 결과를 이 레이어의 y-up 텍스트 공간으로 변환해 그리기만 한다.
-    private func drawText(
+    /// 커맨드 인덱스로 조판 결과를 재사용한다. 인덱스만 믿지 않고 페이로드까지
+    /// 대조하는 이유: `init(layer:)`의 대입은 didSet을 타지 않고, 프로그레시브
+    /// 갱신 경로는 기존 레이어의 paintList를 재대입하지 않는다 (양쪽 뷰의
+    /// `paintList == nil` 가드). 무효화가 새더라도 스테일 배치를 그리지 않게 하는
+    /// 2차 방어선이고, 덕분에 origin·lineWidth 비유한값도 바운드된 미스로 끝난다.
+    private func cachedDrawnLines(
+        commandIndex: Int,
+        attributedString: NSAttributedString,
+        origin: CGPoint,
+        lineWidth: CGFloat
+    ) -> [HwpDrawnLine] {
+        drawnLineCacheLock.lock()
+        let hit = drawnLineCache[commandIndex]
+        drawnLineCacheLock.unlock()
+        if let hit,
+           hit.attributedString === attributedString,
+           hit.origin == origin,
+           hit.lineWidth == lineWidth
+        {
+            return hit.lines
+        }
+
+        // 조판은 락 밖에서 — 비싸고, 드문 중복 계산은 순수 함수라 결과가 같다.
+        let lines = typesetLines(attributedString, origin: origin, lineWidth: lineWidth)
+
+        drawnLineCacheLock.lock()
+        if let stale = drawnLineCache.removeValue(forKey: commandIndex) {
+            cachedLineCount -= stale.lines.count
+        }
+        if cachedLineCount + lines.count <= cachedLineBudget {
+            drawnLineCache[commandIndex] = DrawnLineEntry(
+                attributedString: attributedString,
+                origin: origin,
+                lineWidth: lineWidth,
+                lines: lines
+            )
+            cachedLineCount += lines.count
+        }
+        drawnLineCacheLock.unlock()
+        return lines
+    }
+
+    /// 캐시를 모르는 순수 조판. `drawPlaceholder`처럼 매 draw마다 새 문자열을 만드는
+    /// 경로는 이걸 직접 부른다 — 그 문자열은 draw 종료와 함께 해제되므로 캐시에
+    /// 넣으면 엔트리가 무한 증식하거나 주소 재사용으로 오조판이 난다.
+    ///
+    /// `maxLineFrames`는 항상 기본값 (`HwpParagraphLayout.maximumLineFrames` — static
+    /// let 상수)이라 캐시 키에서 생략한다. 여기에 인자를 노출하게 되면 키에도
+    /// 반드시 넣어야 한다.
+    private func typesetLines(
         _ attributedString: NSAttributedString,
         origin: CGPoint,
-        lineWidth: CGFloat,
-        in ctx: CGContext
-    ) {
-        let drawnLines = HwpDrawnTextLayout.lines(
+        lineWidth: CGFloat
+    ) -> [HwpDrawnLine] {
+        drawnLineCacheLock.lock()
+        typesetCallCount += 1
+        drawnLineCacheLock.unlock()
+        return HwpDrawnTextLayout.lines(
             attributedString: attributedString,
             origin: origin,
             lineWidth: lineWidth
         )
+    }
+
+    /// 줄 배치는 `HwpDrawnTextLayout` (렌더·텍스트 선택 공유 — slight-overflow
+    /// 단일 줄, 양쪽 정렬 재조판, baselineLift 포함)이 계산하고, 여기서는
+    /// top-down 결과를 이 레이어의 y-up 텍스트 공간으로 변환해 그리기만 한다.
+    /// 배치가 `pageHeight`·`bounds`·`contentsScale`에 무관하다는 것이 이 분리의
+    /// 요점이다 — 줌 종료·재래스터 재드로에서 캐시가 그대로 유효하다.
+    private func drawTextLines(_ drawnLines: [HwpDrawnLine], in ctx: CGContext) {
         guard !drawnLines.isEmpty else { return }
         let effectivePageHeight = pageHeight > 0 ? pageHeight : bounds.height
         ctx.saveGState()
@@ -238,10 +377,14 @@ public final class HwpPageLayer: CALayer, @unchecked Sendable {
             x: rect.midX - textSize.width / 2,
             y: rect.midY - textSize.height / 2
         )
-        drawText(
-            attributedString,
-            origin: origin,
-            lineWidth: max(textSize.width, 1),
+        // 캐시 우회 — 이 attributedString은 호출마다 새로 만들어져 draw 종료와 함께
+        // 해제된다. 커맨드 인덱스가 없으니 캐시에 닿을 통로 자체가 없다.
+        drawTextLines(
+            typesetLines(
+                attributedString,
+                origin: origin,
+                lineWidth: max(textSize.width, 1)
+            ),
             in: ctx
         )
     }

--- a/Tests/HwpKitNativeTests/HwpPageLayerCacheTests.swift
+++ b/Tests/HwpKitNativeTests/HwpPageLayerCacheTests.swift
@@ -1,0 +1,214 @@
+import CoreGraphics
+import CoreText
+import Foundation
+import HwpKitCore
+@testable import HwpKitNative
+import Nimble
+import XCTest
+
+private func makeBitmapContext(width: Int = 200, height: Int = 120) -> CGContext? {
+    CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    )
+}
+
+private func imageBytes(in image: CGImage) -> [UInt8] {
+    guard let data = image.dataProvider?.data,
+          let bytes = CFDataGetBytePtr(data)
+    else { return [] }
+    return Array(UnsafeBufferPointer(start: bytes, count: CFDataGetLength(data)))
+}
+
+private func makeText(_ string: String) -> NSAttributedString {
+    NSAttributedString(
+        string: string,
+        attributes: [
+            .font: CTFontCreateWithName("Helvetica" as CFString, 14, nil),
+            .foregroundColor: CGColor(gray: 0, alpha: 1),
+        ]
+    )
+}
+
+private func makeTextLayer(_ commands: [HwpPaintCommand]) -> HwpPageLayer {
+    let layer = HwpPageLayer()
+    layer.bounds = CGRect(x: 0, y: 0, width: 200, height: 120)
+    layer.pageHeight = 120
+    layer.paintList = HwpPaintList(commands: commands)
+    return layer
+}
+
+private func drawnBytes(_ layer: HwpPageLayer) throws -> [UInt8] {
+    let context = try XCTUnwrap(makeBitmapContext())
+    layer.draw(in: context)
+    return imageBytes(in: try XCTUnwrap(context.makeImage()))
+}
+
+/// `HwpPageLayer`의 줄 배치 캐시 (#70) — 재드로 시 재조판이 사라지는지, 그리고
+/// 캐시가 렌더를 바꾸지 않는지. 기존 `HwpPageLayerTests`는 전부 draw 1회라
+/// 콜드 경로만 타므로 캐시 버그를 하나도 잡지 못한다.
+final class HwpPageLayerCacheTests: XCTestCase {
+    /// 같은 paintList로 두 번 그리면 2회째 조판은 0회이고 픽셀은 바이트 동일하다.
+    /// (핀치 줌 종료·이미지 디코딩 완료 재드로가 정확히 이 경로다.)
+    func testRepeatedDrawReusesCachedLineLayout() throws {
+        let layer = makeTextLayer([
+            .drawText(
+                attributedString: makeText("재조판 캐시 검증용 문장입니다"),
+                origin: CGPoint(x: 8, y: 8),
+                lineWidth: 180
+            ),
+        ])
+
+        let first = try drawnBytes(layer)
+        expect(layer.typesetCount) == 1
+        expect(layer.cachedDrawnLineEntryCount) == 1
+
+        let second = try drawnBytes(layer)
+        expect(layer.typesetCount) == 1 // 2회째는 재조판 없음
+        expect(second) == first
+    }
+
+    /// contentsScale·bounds 변경은 줄 배치의 입력이 아니므로 캐시를 무효화하지
+    /// 않는다 — 줌 종료 재드로에서 재조판이 0이 되는 지점.
+    func testContentsScaleChangeDoesNotInvalidateCache() throws {
+        let layer = makeTextLayer([
+            .drawText(
+                attributedString: makeText("줌 종료 재드로"),
+                origin: CGPoint(x: 8, y: 8),
+                lineWidth: 180
+            ),
+        ])
+
+        _ = try drawnBytes(layer)
+        expect(layer.typesetCount) == 1
+
+        layer.contentsScale = 3
+        _ = try drawnBytes(layer)
+        expect(layer.typesetCount) == 1
+    }
+
+    /// 플레이스홀더는 매 draw마다 새 NSAttributedString을 만든다 — 캐시에 들어가면
+    /// 엔트리가 무한 증식하고, 해제된 주소가 재사용되면 오조판까지 난다.
+    /// 커맨드 인덱스 키라 캐시에 닿을 통로 자체가 없어야 한다.
+    func testPlaceholderDrawsBypassCache() throws {
+        let layer = makeTextLayer([
+            .drawImageReference(
+                binItemId: 1,
+                rect: CGRect(x: 0, y: 0, width: 100, height: 100)
+            ),
+        ])
+
+        for _ in 0 ..< 50 {
+            _ = try drawnBytes(layer)
+        }
+
+        expect(layer.cachedDrawnLineEntryCount) == 0
+        expect(layer.typesetCount) == 50
+    }
+
+    /// 같은 rect·다른 텍스트의 플레이스홀더가 서로 오염되지 않는다.
+    /// (NSAttributedString 신원을 키로 썼다면 주소 재사용으로 깨질 수 있던 지점.)
+    func testDistinctPlaceholderTextsInSameRectRenderDistinctly() throws {
+        let rect = CGRect(x: 0, y: 0, width: 120, height: 40)
+        func bytes(_ texts: [String]) throws -> [UInt8] {
+            try drawnBytes(makeTextLayer(
+                texts.map { .drawPlaceholder(rect: rect, text: $0) }
+            ))
+        }
+
+        // 뒤 명령이 같은 rect를 덮으므로 결과는 마지막 텍스트만 그린 것과 같다.
+        expect(try bytes(["AAAA", "MMMM"])) == (try bytes(["MMMM"]))
+        // 두 텍스트가 실제로 다르게 그려지는지 (위 단언이 공허하지 않은지) 확인
+        expect(try bytes(["MMMM"])).toNot(equal(try bytes(["AAAA"])))
+    }
+
+    /// paintList 재대입은 didSet에서 캐시를 전량 비운다.
+    func testPaintListReassignmentInvalidatesCache() throws {
+        let layer = makeTextLayer([
+            .drawText(
+                attributedString: makeText("이전 문단"),
+                origin: CGPoint(x: 8, y: 8),
+                lineWidth: 180
+            ),
+        ])
+        _ = try drawnBytes(layer)
+        expect(layer.cachedDrawnLineEntryCount) == 1
+
+        layer.paintList = HwpPaintList(commands: [
+            .drawText(
+                attributedString: makeText("교체된 문단"),
+                origin: CGPoint(x: 8, y: 8),
+                lineWidth: 180
+            ),
+        ])
+        expect(layer.cachedDrawnLineEntryCount) == 0
+
+        // 새 레이어로 교체본만 그린 결과와 픽셀 동일 — 스테일 배치가 남지 않는다
+        let fresh = makeTextLayer([
+            .drawText(
+                attributedString: makeText("교체된 문단"),
+                origin: CGPoint(x: 8, y: 8),
+                lineWidth: 180
+            ),
+        ])
+        expect(try drawnBytes(layer)) == (try drawnBytes(fresh))
+    }
+
+    /// CA 사본 (`init(layer:)`)은 캐시를 물려받지 않는다. 그 대입은 super.init
+    /// 이전이라 didSet이 발화하지 않으므로, 캐시를 복사하면 무효화 계약이 깨진다.
+    func testLayerCopyStartsWithEmptyCache() throws {
+        let layer = makeTextLayer([
+            .drawText(
+                attributedString: makeText("사본 검증"),
+                origin: CGPoint(x: 8, y: 8),
+                lineWidth: 180
+            ),
+        ])
+        let original = try drawnBytes(layer)
+        expect(layer.cachedDrawnLineEntryCount) == 1
+
+        let copy = HwpPageLayer(layer: layer)
+        copy.bounds = layer.bounds
+        expect(copy.cachedDrawnLineEntryCount) == 0
+        expect(copy.typesetCount) == 0
+        expect(try drawnBytes(copy)) == original
+    }
+
+    /// 줄 예산을 넘기면 축출이 아니라 **삽입 중단**이다 — draw가 커맨드를 항상
+    /// 같은 순서로 훑으므로 FIFO 축출은 히트율 0%가 된다. 예산 밖 명령은 현행대로
+    /// 매번 재조판하되 렌더는 동일해야 한다.
+    func testCachedLineBudgetStopsInsertingWithoutEvicting() throws {
+        func makeCommands() -> [HwpPaintCommand] {
+            (0 ..< 3).map { index in
+                .drawText(
+                    attributedString: makeText("예산 \(index)"),
+                    origin: CGPoint(x: 8, y: 8 + CGFloat(index) * 24),
+                    lineWidth: 180
+                )
+            }
+        }
+
+        let limited = HwpPageLayer()
+        limited.bounds = CGRect(x: 0, y: 0, width: 200, height: 120)
+        limited.pageHeight = 120
+        limited.cachedLineBudget = 1 // 명령당 1줄이라 첫 명령만 들어간다
+        limited.paintList = HwpPaintList(commands: makeCommands())
+
+        let first = try drawnBytes(limited)
+        expect(limited.typesetCount) == 3
+        expect(limited.cachedDrawnLineEntryCount) == 1
+
+        let second = try drawnBytes(limited)
+        expect(limited.typesetCount) == 5 // 첫 명령만 히트, 나머지 2개는 재조판
+        expect(limited.cachedDrawnLineEntryCount) == 1 // 축출 없음
+        expect(second) == first
+
+        // 예산이 넉넉한 레이어와 렌더가 동일하다
+        expect(second) == (try drawnBytes(makeTextLayer(makeCommands())))
+    }
+}


### PR DESCRIPTION
Closes #70

## 요약

`HwpPageLayer`의 `.drawText`가 **매 draw마다** `HwpDrawnTextLayout.lines`(framesetter + frame)로 재조판하던 것을, 레이어 인스턴스 안 캐시로 없앴다.

re-draw는 흔하다 — contentsScale 변경(핀치 줌 종료·Retina), bounds 변경(`needsDisplayOnBoundsChange`), 이미지 디코딩 완료·디퍼드 용량 확보 콜백. **줄 기하는 pt 단위라 이 중 어느 것도 배치를 바꾸지 않는데도** 매번 CoreText를 다시 돌렸다.

`drawText`를 조회(`cachedDrawnLines`) · 순수 조판(`typesetLines`) · 렌더(`drawTextLines`) 셋으로 쪼개, 배치가 `pageHeight`·`bounds`·`contentsScale`과 무관하다는 사실을 구조로 드러낸다.

## 이슈 원안에서 바꾼 설계

- **키를 NSAttributedString의 `ObjectIdentifier`가 아니라 커맨드 인덱스로.** 원안의 신원 해싱을 쓰면 `drawPlaceholder`가 draw마다 만드는 임시 문자열이 해제된 뒤 주소가 재사용될 때, 같은 rect의 플레이스홀더끼리 origin·lineWidth까지 일치해 **엉뚱한 히트로 조용한 오조판**이 난다. 인덱스 키는 `drawPlaceholder`가 커맨드 인덱스를 갖지 않으므로 캐시 우회를 코드(플래그)가 아니라 구조로 강제한다.
- **히트 시 페이로드 재검증(`===` + origin/lineWidth)을 2차 방어선으로 추가.** 원안은 didSet 무효화만 믿었으나 `init(layer:)`의 대입은 `super.init` 이전이라 didSet이 발화하지 않고, 프로그레시브 갱신은 양쪽 뷰의 `paintList == nil` 가드 때문에 기존 레이어에 재대입하지 않는다. 무효화가 새도 오조판은 불가능해진다.
- **상한 초과 시 축출이 아니라 삽입 중단.** draw는 커맨드를 항상 같은 순서로 전량 훑으므로 FIFO 축출은 워킹셋이 상한보다 큰 페이지에서 히트율 0% + 매 draw 전량 재삽입이 된다. 상한도 엔트리 수가 아니라 누적 줄 수(`cachedLineBudget` 기본 8,192)로 잡는다 — 엔트리 하나가 `maximumLineFrames`(=100,000) 줄까지 담을 수 있어 엔트리 수 상한은 CTLine 보유량을 전혀 묶지 못한다.
- **재진입 데드락 대응은 불필요했다** — `drawText` → `drawPlaceholder` 방향은 단방향 1단계다. 대신 "락은 조판·그리기 중 보유 금지"를 구조로 지킨다(`NSLock`은 딕셔너리 조회/저장 순간에만).

## 실측 (macOS, 재드로 20회, 캐시 무력화 A/B)

| 픽스처 | before | after | 배수 | 조판 호출 |
|---|---|---|---|---|
| Column (1쪽, drawText 11) | 681.0ms | 368.9ms | **1.85x** | 220 → 0회 |
| noori (3쪽, drawText 64) | 913.9ms | 596.4ms | **1.53x** | 1360 → 80회 |

noori의 잔여 80 = 플레이스홀더 4개 × 20회 — **설계대로 캐시를 우회한다.** 남은 시간은 CTLineDraw·장식 등 실제 그리기라 캐시가 줄일 수 없는 몫이고, 레이어가 객체째 폐기·재생성되는 스크롤은 콜드 경로라 이득이 없다.

## 렌더 불변 증명

수정 전 기준선을 동결하고(`RECORD_RENDER_HASHES=1`) 수정 후 **픽셀 해시 29개 픽스처가 양 폰트 모드(기본 · `HWP_HANCOM_FONTS=1`)에서 무변화**. 블록 스냅샷 · fidelity · 전체 1,195 테스트 그린, iOS 빌드 성공.

## 함께 들어간 변경

- **`fix:` 메모 패널 헤더 문자열 동결** — `HwpPaintCommand`는 `.drawText` 페이로드가 immutable 인스턴스여야 한다고 계약하는데, 실제 생산 경로에서 이 계약이 새는 유일한 지점이 메모 패널 헤더였다(`NSMutableAttributedString`을 동결 없이 그대로 실었다). 지금은 함수 로컬이라 실해가 없지만, 줄 배치 캐시가 문자열 신원(`===`)으로 조판 결과를 재사용하므로 **"신원이 같으면 내용도 같다"가 전 경로에서 성립해야** 한다.
- **`docs:` AGENTS.md 3종 갱신** — HwpKitNative에 캐시 절(키 선택 근거 · 무효화 · 상한 정책 · 락 규약 · 실측 · 회귀 가드), HwpKitCore의 paint 명령 동결 계약에 painter 직접 생산 경로와 새 소비자, 루트에 렌더 최적화 증명 방법론(속도는 무력화 A/B 실측, 등가성은 양 폰트 모드 픽셀 해시 무변화).

## 테스트

신규 `Tests/HwpKitNativeTests/HwpPageLayerCacheTests.swift` 7종이 캐시 히트(조판 0회) · contentsScale 변경 시 무효화 없음 · 플레이스홀더 우회 · paintList 재대입 무효화 · CA 사본 빈 캐시 · 예산 초과 시 축출 없음을 고정한다.

**기존 테스트는 전부 draw 1회라 콜드 경로만 타서 캐시 버그를 잡지 못한다** — 캐시를 건드리는 후속 작업은 draw를 2회 이상 돌리고 `typesetCount` / `cachedDrawnLineEntryCount`(테스트 전용 관측점)로 단언해야 한다.

## 후속 관계

#72(paintList 지연화)보다 이 PR이 먼저 들어가는 것이 이슈 #70의 권고였고, 그대로 따랐다 — 순서가 뒤바뀌면 paintList 재구축이 캐시를 통째로 무효화해 이득이 사라진다.

---
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
