### PR TITLE
[성능] 문서 단위 charShape 별 HwpTextAttributeCache 도입

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # 프로젝트 지식 베이스
 
-**Branch:** perf/page-layer-drawn-line-cache
+**Branch:** perf/text-attribute-cache
 
 ## 개요
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,9 +149,13 @@ pre-commit install && pre-commit run --all     # hook 설치 + 전체 실행
 PR은 실측 수치를 커밋 메시지에 기록한다.
 
 렌더 경로 최적화(캐시 도입 등)는 **속도는 실측, 등가성은 해시**로 나눠
-증명한다: 같은 문서를 최적화 무력화 A/B로 N회 재드로해 배수를 재고, 같은
-PR에서 픽셀 해시가 **양 폰트 모드 모두 무변화**임을 함께 보인다 (예:
-`HwpPageLayer` 줄 배치 캐시 1.85x/1.53x — `Sources/HwpKitNative/AGENTS.md`).
+증명한다: 같은 문서를 최적화 무력화 A/B로 N회 재조판·재드로해 배수를 재고,
+같은 PR에서 픽셀 해시가 **양 폰트 모드 모두 무변화**임을 함께 보인다.
+캐시는 파이프라인 단계로 층이 갈린다 — 조판 **입력**은 `HwpTextAttributeCache`
+(글자 모양별 속성 사전; paginate 1.78x, 1,030쪽 문서 로드 1.42x —
+`Sources/HwpKitCore/AGENTS.md`), 조판 **결과**는 `HwpPageLayer` 줄 배치 캐시
+(재드로 1.85x/1.53x — `Sources/HwpKitNative/AGENTS.md`). 문서 빌드와 draw로
+단계가 갈려 서로 독립이다.
 
 ## 리뷰 대응 체크리스트 (렌더 회귀 방지)
 

--- a/Sources/HwpKitCore/AGENTS.md
+++ b/Sources/HwpKitCore/AGENTS.md
@@ -210,6 +210,21 @@ CT 측정보다 우선한다 — 폰트 대체로 줄 수가 부풀어 배치가
   바탕이 아니라 한자용 송체이고 (문서의 `FaceName.defaultFaceName` 이
   `FZSong_Superfont` 로 못박는다), `Apple SD 산돌고딕 Neo` 는 시스템 폰트의
   한글 표시명이라 매핑이 없으면 로마자 슬롯이 Helvetica 로 대체된다
+- **글자 모양 속성 캐시** (`HwpTextAttributeCache`) — `HwpTextRunBuilder.attributes`
+  는 `index`·`fontResolver` 가 고정이면 `(shapeId, script)` 의 순수 함수라
+  (장평·이탤릭 근사 매트릭스·라틴 세리프 폴백·장식이 전부 charShape 에서만
+  나온다) 텍스트 조각마다 하던 재계산을 메모한다. 문단마다 달라지는 값
+  (변경추적 표시·메모 앵커·controlIndex·run delegate·첨자 치환)은 전부 **반환
+  뒤** 사전 사본에 붙으므로 키에서 구조적으로 빠져 있다. 지켜야 할 것 셋:
+  ① **돌려받은 사전을 제자리에서 변형 금지** — 공유 인스턴스라 값
+  (CTFont/CGColor/NSNumber)을 바꾸면 다른 호출부까지 오염된다. `var` 사본에
+  키 추가·치환만 한다. `attributes` 에 가변 NSObject (NSShadow·
+  NSMutableParagraphStyle 등)를 새로 넣으면 이 계약이 조용히 깨진다.
+  ② **소유는 문서 단위** (`HwpPaginator` 가 하나 만들어 표/글상자/각주/크롬에
+  주입) — `shapeId` 의 의미가 `HwpIndex` 마다 다르고 `usesInstalledHancomFonts`
+  는 resolver 별 값이라, 전역·resolver 소유면 문서·폰트 모드가 섞인다.
+  ③ 그 규약을 타입으로 강제할 수 없어 **캐시 타입과 캐시를 받는 init 은 전부
+  internal** 이다. public init 은 캐시 없는 기존 시그니처를 유지한다
 - 실측 튜닝 상수는 `Tuning/HwpRenderTuning.swift` 에 근거 주석과 함께 —
   값 변경은 fidelity 전수 + 블록 스냅샷 + 실물 대조 필수 (값 핀:
   `HwpRenderTuningTests`). 차트 투영 기하 (`HwpChartPainter`)와 각주 예약

--- a/Sources/HwpKitCore/AGENTS.md
+++ b/Sources/HwpKitCore/AGENTS.md
@@ -229,8 +229,16 @@ CT 측정보다 우선한다 — 폰트 대체로 줄 수가 부풀어 배치가
   호출마다 `CTTextTab` 을 새로 만드는데 문단마다 측정·렌더로 불린다). 키가
   `tabDefId` **하나뿐**이라, `HwpIndex.textTabs(for:)` 가 paraShape 의 다른
   필드를 보게 되면 조용히 틀린 탭을 준다 (실측 확인: 현재는 `tabDefId` 만
-  읽는다). 속성 쪽도 같은 성질이라 `attributes(forShapeId:shape:script:)` 의
-  `shape` 는 **그 `shapeId` 로 만든 것**이어야 한다 — 키에 shape 내용이 없다.
+  읽는다). 속성 키도 같은 성질이지만 그쪽은 타입이 막는다 — `resolvedShape` 가
+  shape 와 캐시 키를 `ResolvedShape` 한 값으로 묶어 주고 `attributes(for:script:)`
+  가 그 타입만 받아, 어긋난 짝을 넘길 길이 없다.
+  **`index` 에 없는 id 는 캐시 키가 `nil` 로 접힌다** — 폴백 (`resolvedShape`) 이
+  문단과 무관한 상수라 결과 사전이 전부 같은데, 원본 id 로 키를 잡으면 조작
+  문서가 문자마다 다른 id 를 흘려 내용이 같은 항목을 문서 수명 내내 쌓는다.
+  저장소별 항목 상한 (`maximumStoredEntries` 65,536)은 **축출이 아니라 삽입
+  중단**이다 — 조판이 문서를 순서대로 훑으므로 FIFO 축출은 워킹셋이 상한보다
+  클 때 히트율 0% 가 된다 (`HwpPageLayer` 줄 배치 캐시와 같은 이유). 미스가
+  `create` 폴백이라 삽입을 멈춰도 결과는 같다.
   주입 경로는 ②의 넷 말고 `HwpParagraphMeasurer` · `HwpParagraphObjectCollector`
   까지다 (컨테이너 안 글상자가 자체 `HwpTextboxLayout` 을 만드는 경로) —
   **새 레이아웃 컴포넌트는 캐시를 함께 실을 것**.
@@ -241,9 +249,10 @@ CT 측정보다 우선한다 — 폰트 대체로 줄 수가 부풀어 배치가
   실측 (로컬 macOS, 3회 median, 캐시 무력화 A/B): paginate N=20,000 (589쪽)
   10.95 → 6.17s (**1.78x**), legacy 1,030쪽 문서 로드 26.37 → 18.53s
   (**1.42x**). 등가성은 렌더 픽셀 해시 전 픽스처 × 전 페이지 0건 (양 폰트
-  모드). 회귀 가드는 `HwpTextRunBuilderTests` 의 캐시 5종 (캐시/무캐시 문자열
+  모드). 회귀 가드는 `HwpTextRunBuilderTests` 의 캐시 7종 (캐시/무캐시 문자열
   동치, 히트·미스 카운트, script 키 분리, 변경추적 마크 비오염, 탭 스톱
-  재사용) — 캐시를 건드리면 `hitCount`/`missCount` (테스트 전용 관측점) 로
+  재사용, 미해결 id 64개 → 항목 1개, 상한 초과 시 삽입 중단 + 결과 불변) —
+  캐시를 건드리면 `hitCount`/`missCount`/`entryCount` (테스트 전용 관측점) 로
   단언할 것
 - 실측 튜닝 상수는 `Tuning/HwpRenderTuning.swift` 에 근거 주석과 함께 —
   값 변경은 fidelity 전수 + 블록 스냅샷 + 실물 대조 필수 (값 핀:

--- a/Sources/HwpKitCore/AGENTS.md
+++ b/Sources/HwpKitCore/AGENTS.md
@@ -9,7 +9,7 @@ CoreHwp.HwpFile
   → HwpDocumentActor.buildDocument (HwpKitNative)
      → HwpIndex             # docInfo.idMappings 인덱싱 (charShape/paraShape/…)
      → HwpImageStore        # binItemId(1-based) → BinData 바이트 조인
-     → HwpPaginator (actor) # 페이지 lazy 생성
+     → HwpPaginator (actor) # 페이지 lazy 생성 + 문서 단위 HwpTextAttributeCache 소유
         ├─ per paragraph
         │   flushPageBeforeProcessing  # 구역 시작·쪽 나누기 (columnType bit 2) 페이지 확정
         │   applySectionDef / applyColumnDef   # 구역 지오메트리 + 단 밴드 전환
@@ -224,7 +224,27 @@ CT 측정보다 우선한다 — 폰트 대체로 줄 수가 부풀어 배치가
   주입) — `shapeId` 의 의미가 `HwpIndex` 마다 다르고 `usesInstalledHancomFonts`
   는 resolver 별 값이라, 전역·resolver 소유면 문서·폰트 모드가 섞인다.
   ③ 그 규약을 타입으로 강제할 수 없어 **캐시 타입과 캐시를 받는 init 은 전부
-  internal** 이다. public init 은 캐시 없는 기존 시그니처를 유지한다
+  internal** 이다. public init 은 캐시 없는 기존 시그니처를 유지한다.
+  탭 스톱도 같은 캐시에 있다 (`textTabs(for:index:)` — `HwpIndex.textTabs` 는
+  호출마다 `CTTextTab` 을 새로 만드는데 문단마다 측정·렌더로 불린다). 키가
+  `tabDefId` **하나뿐**이라, `HwpIndex.textTabs(for:)` 가 paraShape 의 다른
+  필드를 보게 되면 조용히 틀린 탭을 준다 (실측 확인: 현재는 `tabDefId` 만
+  읽는다). 속성 쪽도 같은 성질이라 `attributes(forShapeId:shape:script:)` 의
+  `shape` 는 **그 `shapeId` 로 만든 것**이어야 한다 — 키에 shape 내용이 없다.
+  주입 경로는 ②의 넷 말고 `HwpParagraphMeasurer` · `HwpParagraphObjectCollector`
+  까지다 (컨테이너 안 글상자가 자체 `HwpTextboxLayout` 을 만드는 경로) —
+  **새 레이아웃 컴포넌트는 캐시를 함께 실을 것**.
+  안 실어도 결과는 같고 (nil 이면 매번 재계산) 조용히 느려질 뿐이라 테스트로
+  안 잡힌다. 동기화는 `NSLock` 으로 저장소 접근만 감싸고 `create` 는 lock
+  밖이다 (`HwpFontResolver.FontCache` 와 같은 절충 — 경합하면 같은 키를 두 번
+  만들 수 있지만 순수 함수라 결과가 같다).
+  실측 (로컬 macOS, 3회 median, 캐시 무력화 A/B): paginate N=20,000 (589쪽)
+  10.95 → 6.17s (**1.78x**), legacy 1,030쪽 문서 로드 26.37 → 18.53s
+  (**1.42x**). 등가성은 렌더 픽셀 해시 전 픽스처 × 전 페이지 0건 (양 폰트
+  모드). 회귀 가드는 `HwpTextRunBuilderTests` 의 캐시 5종 (캐시/무캐시 문자열
+  동치, 히트·미스 카운트, script 키 분리, 변경추적 마크 비오염, 탭 스톱
+  재사용) — 캐시를 건드리면 `hitCount`/`missCount` (테스트 전용 관측점) 로
+  단언할 것
 - 실측 튜닝 상수는 `Tuning/HwpRenderTuning.swift` 에 근거 주석과 함께 —
   값 변경은 fidelity 전수 + 블록 스냅샷 + 실물 대조 필수 (값 핀:
   `HwpRenderTuningTests`). 차트 투영 기하 (`HwpChartPainter`)와 각주 예약

--- a/Sources/HwpKitCore/Layout/HwpFootnoteLayout.swift
+++ b/Sources/HwpKitCore/Layout/HwpFootnoteLayout.swift
@@ -40,9 +40,17 @@ public struct HwpFootnoteBlock: @unchecked Sendable, Hashable {
 /// 가져오고, 길이가 자동(-1)이면 단 폭의 1/3을 쓴다.
 public struct HwpFootnoteLayout {
     private let fontResolver: HwpFontResolver
+    /// 각주 문단이 본문과 같은 글자 모양 속성 캐시를 쓰게 한다 (소유는 `HwpPaginator`).
+    private let attributeCache: HwpTextAttributeCache?
 
     public init(fontResolver: HwpFontResolver = HwpFontResolver()) {
+        self.init(fontResolver: fontResolver, attributeCache: nil)
+    }
+
+    /// 캐시를 주입하는 모듈 내부용 init (`HwpTextAttributeCache` 참조).
+    init(fontResolver: HwpFontResolver, attributeCache: HwpTextAttributeCache?) {
         self.fontResolver = fontResolver
+        self.attributeCache = attributeCache
     }
 
     public struct Input {
@@ -348,7 +356,9 @@ public struct HwpFootnoteLayout {
         width: CGFloat,
         footnoteShape: CoreHwp.HwpFootnoteShape? = nil
     ) -> [MeasuredFootnote] {
-        let measurer = HwpParagraphMeasurer(index: index, fontResolver: fontResolver)
+        let measurer = HwpParagraphMeasurer(
+            index: index, fontResolver: fontResolver, attributeCache: attributeCache
+        )
         return footnotes.map { input in
             // 각주 첫머리의 자동 번호 (ext18) 마커를 번호 문자열로 치환한다
             // (번호는 paginator가 부여한 문서 순서 번호 — 본문 참조와 동일 소스).

--- a/Sources/HwpKitCore/Layout/HwpPaginator.swift
+++ b/Sources/HwpKitCore/Layout/HwpPaginator.swift
@@ -9,6 +9,10 @@ public actor HwpPaginator {
     private let sections: [CoreHwp.HwpSection]
     private let index: HwpIndex
     private let fontResolver: HwpFontResolver
+    /// 글자 모양별 텍스트 속성 캐시 — 문서(파이프라인) 단위 소유. 본문·표 셀·
+    /// 글상자·각주·머리말/꼬리말이 전부 이 하나를 공유한다. 전역이면 안 되는
+    /// 이유는 `HwpTextAttributeCache` 참조.
+    private let attributeCache = HwpTextAttributeCache()
     private let imageStore: HwpImageStore
     private let paintListBuilder: HwpPaintListBuilder
     private let unsupportedDetector = HwpUnsupportedDetector()
@@ -204,10 +208,18 @@ public actor HwpPaginator {
         self.fontResolver = fontResolver
         self.imageStore = imageStore
         paintListBuilder = HwpPaintListBuilder(fontResolver: fontResolver, imageStore: imageStore)
-        tableLayout = HwpTableLayout(fontResolver: fontResolver)
-        textboxLayout = HwpTextboxLayout(fontResolver: fontResolver)
-        footnoteCoordinator = HwpFootnoteCoordinator(index: index, fontResolver: fontResolver)
-        pageChrome = HwpPageChromeBuilder(index: index, fontResolver: fontResolver)
+        tableLayout = HwpTableLayout(
+            fontResolver: fontResolver, attributeCache: attributeCache
+        )
+        textboxLayout = HwpTextboxLayout(
+            fontResolver: fontResolver, attributeCache: attributeCache
+        )
+        footnoteCoordinator = HwpFootnoteCoordinator(
+            index: index, fontResolver: fontResolver, attributeCache: attributeCache
+        )
+        pageChrome = HwpPageChromeBuilder(
+            index: index, fontResolver: fontResolver, attributeCache: attributeCache
+        )
         absoluteCachePlacer = HwpAbsoluteCachePlacer(sections: sections)
         currentPageGeometry = Self.initialGeometry(for: sections)
         currentSectionDef = Self.firstSectionDef(for: sections)
@@ -900,7 +912,7 @@ private extension HwpPaginator {
             attributedString: attributedString,
             paraShape: paraShape,
             columnWidth: currentColumnFrame.width,
-            tabStops: index.textTabs(for: paraShape)
+            tabStops: attributeCache.textTabs(for: paraShape, index: index)
         )
     }
 
@@ -1831,7 +1843,8 @@ private extension HwpPaginator {
         HwpTextRunBuilder(
             index: index,
             fontResolver: fontResolver,
-            sizeResolver: objectSizeResolver
+            sizeResolver: objectSizeResolver,
+            attributeCache: attributeCache
         )
     }
 
@@ -2309,10 +2322,12 @@ private extension HwpPaginator {
             var total = 0
             for memoParagraph in group where total < budget {
                 let remainingBudget = budget - total
-                let text = HwpTextRunBuilder(index: index, fontResolver: fontResolver)
-                    .build(paragraph: memoParagraph, maxCharacters: remainingBudget)
-                    .string
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let text = HwpTextRunBuilder(
+                    index: index, fontResolver: fontResolver, attributeCache: attributeCache
+                )
+                .build(paragraph: memoParagraph, maxCharacters: remainingBudget)
+                .string
+                .trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else { continue }
                 let clipped = text.count > remainingBudget
                     ? String(text.prefix(remainingBudget))

--- a/Sources/HwpKitCore/Layout/HwpParagraphMeasurer.swift
+++ b/Sources/HwpKitCore/Layout/HwpParagraphMeasurer.swift
@@ -23,6 +23,10 @@ struct HwpParagraphMeasurer {
     let index: HwpIndex
     let fontResolver: HwpFontResolver
     var sizeResolver: HwpObjectSizeResolver?
+    /// 글자 모양별 속성 사전 캐시 (소유는 `HwpPaginator`) — 표 셀·글상자·각주가
+    /// 본문과 같은 캐시를 쓰게 한다. 멤버와이즈 init의 기본값이 nil이라 캐시를
+    /// 넘기지 않는 호출부는 동작이 그대로다.
+    var attributeCache: HwpTextAttributeCache?
 
     /// 호출부별 차이를 보존하는 훅.
     struct Options {
@@ -52,7 +56,8 @@ struct HwpParagraphMeasurer {
         let attributed = HwpTextRunBuilder(
             index: index,
             fontResolver: fontResolver,
-            sizeResolver: sizeResolver
+            sizeResolver: sizeResolver,
+            attributeCache: attributeCache
         )
         .build(paragraph: paragraph, controlReplacements: options.controlReplacements)
         let paraShape = index.paraShapeOrDefault(for: paragraph)
@@ -60,7 +65,8 @@ struct HwpParagraphMeasurer {
             attributedString: attributed,
             paraShape: paraShape,
             columnWidth: width,
-            tabStops: index.textTabs(for: paraShape)
+            tabStops: attributeCache?.textTabs(for: paraShape, index: index)
+                ?? index.textTabs(for: paraShape)
         )
         // 표 43 여백 계열과 같은 1/2 단위 (HwpParagraphMetrics와 동일).
         let spacingBefore = options.addHalfSpacingBefore

--- a/Sources/HwpKitCore/Layout/HwpParagraphObjectCollector.swift
+++ b/Sources/HwpKitCore/Layout/HwpParagraphObjectCollector.swift
@@ -13,6 +13,9 @@ struct HwpParagraphObjectCollector {
     let sizeResolver: HwpObjectSizeResolver?
     /// 글상자 수집 여부 — 글상자 안 글상자 재귀를 막는다 (표 셀만 참)
     let collectsTextboxes: Bool
+    /// 글자 모양별 속성 캐시 (소유는 `HwpPaginator`) — 컨테이너 안 글상자가
+    /// 자체 `HwpTextboxLayout`을 만들 때 캐시를 잃지 않게 한다.
+    var attributeCache: HwpTextAttributeCache?
 
     struct Objects {
         var images: [HwpCellImage] = []
@@ -303,7 +306,9 @@ struct HwpParagraphObjectCollector {
         // 폴백. 억제 (collectible)는 property를 보지 않는다 — nil 수집 거부는
         // 흐름·컨테이너 양쪽 모두 렌더하지 않는 소실이 된다 (R30 #4).
         let property = commonProperty ?? CoreHwp.HwpCommonCtrlProperty()
-        guard let frame = HwpTextboxLayout(fontResolver: fontResolver).layout(
+        guard let frame = HwpTextboxLayout(
+            fontResolver: fontResolver, attributeCache: attributeCache
+        ).layout(
             components: [component],
             commonProperty: property,
             fallbackWidth: placement.paragraphRect.width,

--- a/Sources/HwpKitCore/Layout/HwpTableLayout.swift
+++ b/Sources/HwpKitCore/Layout/HwpTableLayout.swift
@@ -5,9 +5,17 @@ import Foundation
 
 public struct HwpTableLayout {
     let fontResolver: HwpFontResolver
+    /// 셀 문단이 본문과 같은 글자 모양 속성 캐시를 쓰게 한다 (소유는 `HwpPaginator`).
+    let attributeCache: HwpTextAttributeCache?
 
     public init(fontResolver: HwpFontResolver = HwpFontResolver()) {
+        self.init(fontResolver: fontResolver, attributeCache: nil)
+    }
+
+    /// 캐시를 주입하는 모듈 내부용 init (`HwpTextAttributeCache` 참조).
+    init(fontResolver: HwpFontResolver, attributeCache: HwpTextAttributeCache?) {
         self.fontResolver = fontResolver
+        self.attributeCache = attributeCache
     }
 
     /// 재귀 중첩 표 레이아웃 깊이 상한 (바깥 표 = 0)
@@ -279,7 +287,8 @@ extension HwpTableLayout {
         // '문단' 기준 개체는 셀 안에서 셀 안폭을 기준으로 해석한다 (#2)
         let measurer = HwpParagraphMeasurer(
             index: context.index, fontResolver: fontResolver,
-            sizeResolver: context.sizeResolver?.withParagraphWidth(innerWidth)
+            sizeResolver: context.sizeResolver?.withParagraphWidth(innerWidth),
+            attributeCache: attributeCache
         )
 
         let measured = measuredCellContents(

--- a/Sources/HwpKitCore/Layout/HwpTableLayoutFrames.swift
+++ b/Sources/HwpKitCore/Layout/HwpTableLayoutFrames.swift
@@ -231,13 +231,15 @@ extension HwpTableLayout {
         let innerWidth = max(1, cellRect.width - margins.left - margins.right)
         let cellResolver = sizeResolver?.withParagraphWidth(innerWidth)
         let textBuilder = HwpTextRunBuilder(
-            index: index, fontResolver: fontResolver, sizeResolver: cellResolver
+            index: index, fontResolver: fontResolver, sizeResolver: cellResolver,
+            attributeCache: attributeCache
         )
         let collector = HwpParagraphObjectCollector(
             index: index,
             fontResolver: fontResolver,
             sizeResolver: cellResolver,
-            collectsTextboxes: true
+            collectsTextboxes: true,
+            attributeCache: attributeCache
         )
         var paragraphs: [HwpLaidOutParagraph] = []
         var nestedTables: [HwpNestedTableFrame] = []

--- a/Sources/HwpKitCore/Layout/HwpTextAttributeCache.swift
+++ b/Sources/HwpKitCore/Layout/HwpTextAttributeCache.swift
@@ -1,0 +1,108 @@
+import CoreHwp
+import CoreText
+import Foundation
+
+/// 글자 모양 (charShape) 별 텍스트 속성 사전 캐시 — 같은 글자 모양을 쓰는 텍스트
+/// 조각마다 속성 사전과 파생 CTFont를 처음부터 다시 만드는 중복을 없앤다.
+///
+/// `HwpTextRunBuilder.attributes(for:script:)`는 `index`·`fontResolver`가 고정일 때
+/// `(shapeId, script)`의 순수 함수다. 장평·이탤릭 근사 매트릭스·라틴 세리프 폴백·
+/// 장식 (밑줄/취소선/음영/그림자/외곽선/양각/강조점/첨자)이 전부 글자 모양에서만
+/// 나오고, 문단마다 달라지는 값 (변경추적 표시·메모 앵커·controlIndex·run
+/// delegate·첨자 치환)은 전부 **반환된 뒤** 사전 사본에 붙기 때문이다. 문서 하나가
+/// 쓰는 글자 모양은 보통 수십 개뿐이라 이 계산의 대부분이 중복이다.
+///
+/// **계약 — 돌려받은 사전을 제자리에서 변형하지 말 것.** 캐시가 같은 사전 (그리고
+/// 그 안의 CTFont/CGColor/NSNumber 인스턴스)을 여러 호출부에 공유하므로, 값을
+/// 제자리에서 바꾸면 다른 호출부까지 오염된다. 호출부는 `var` 사본에 키를 추가·
+/// 치환만 한다 — Swift Dictionary는 값 타입이라 사본 수정이 캐시에 닿지 않고,
+/// CTFont·CGColor는 불변이라 교체만 안전하다. (`HwpFontResolver`가 같은 CTFont
+/// 인스턴스를 이미 여러 run에 나눠 주고 있어 공유 자체는 새 계약이 아니다.)
+///
+/// **소유는 문서 (파이프라인) 단위** — `HwpPaginator.init`이 하나 만들어 하위
+/// 레이아웃에 주입한다. 전역 캐시나 `HwpFontResolver` 소유는 안 된다:
+/// - `shapeId`의 의미가 문서 (`HwpIndex`) 마다 다르다 — 문서를 넘어 공유하면 다른
+///   문서의 글자 모양이 섞인다 (`.testDeterministic` 처럼 여러 문서가 공유하는
+///   resolver가 실재한다).
+/// - `usesInstalledHancomFonts`가 resolver별 값이라 한 프로세스에 opt-in on/off
+///   resolver가 공존할 수 있다 — 전역 캐시는 두 모드의 폰트를 섞는다.
+///
+/// 이 문서 단위 소유 규약을 타입으로 강제할 수단이 없으므로 (키에 `HwpIndex`
+/// 신원이 없다) **internal로 둔다** — 캐시를 받는 init도 전부 internal이라 모듈
+/// 밖에서 다른 문서의 캐시를 넘길 길 자체가 없다. public API는 캐시 없는
+/// 기존 init 그대로다.
+final class HwpTextAttributeCache: @unchecked Sendable {
+    private struct AttributeKey: Hashable {
+        let shapeId: UInt32
+        let script: HwpScript
+    }
+
+    /// 사전과 그 값 (CTFont/CGColor/NSNumber)은 모두 불변으로 다룬다 (위 계약) —
+    /// 저장소 접근만 lock으로 감싼다. `HwpFontResolver.FontCache`와 같은 패턴.
+    private var attributeStorage: [AttributeKey: [NSAttributedString.Key: Any]] = [:]
+    private var tabStorage: [UInt32: [CTTextTab]] = [:]
+    private let lock = NSLock()
+
+    /// 테스트 전용 관측 지점 (`HwpFontResolver.matchCounter`와 같은 역할) — 캐시가
+    /// 실제로 재계산을 없애는지 유닛 테스트가 확인한다. 속성 사전만 센다.
+    private var hits = 0
+    private var misses = 0
+
+    init() {}
+
+    var hitCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return hits
+    }
+
+    var missCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return misses
+    }
+
+    /// `(shapeId, script)`의 텍스트 속성 사전. 없으면 `create`로 만들어 채운다.
+    ///
+    /// `create`는 lock 밖에서 부른다 — CoreText 폰트 생성이 무거워 lock을 쥔 채
+    /// 부르면 병렬 조판이 직렬화된다. 경합하면 같은 키를 두 번 만들 수 있지만 순수
+    /// 함수라 결과가 같다 (`FontCache`와 같은 절충).
+    func attributes(
+        shapeId: UInt32,
+        script: HwpScript,
+        create: () -> [NSAttributedString.Key: Any]
+    ) -> [NSAttributedString.Key: Any] {
+        let key = AttributeKey(shapeId: shapeId, script: script)
+        lock.lock()
+        if let cached = attributeStorage[key] {
+            hits += 1
+            lock.unlock()
+            return cached
+        }
+        misses += 1
+        lock.unlock()
+        let attributes = create()
+        lock.lock()
+        attributeStorage[key] = attributes
+        lock.unlock()
+        return attributes
+    }
+
+    /// 탭 정의 (표 36) 별 CT 탭 스톱. `HwpIndex.textTabs(for:)`는 호출마다
+    /// `CTTextTab`을 새로 만드는데 문단마다 (측정 + 렌더 재조판) 불린다. 결과는
+    /// `tabDefId`만의 함수이고 `CTTextTab`은 불변이라 문서 안에서 공유해도 된다.
+    func textTabs(for paraShape: CoreHwp.HwpParaShape, index: HwpIndex) -> [CTTextTab] {
+        let key = UInt32(paraShape.tabDefId)
+        lock.lock()
+        if let cached = tabStorage[key] {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+        let tabs = index.textTabs(for: paraShape)
+        lock.lock()
+        tabStorage[key] = tabs
+        lock.unlock()
+        return tabs
+    }
+}

--- a/Sources/HwpKitCore/Layout/HwpTextAttributeCache.swift
+++ b/Sources/HwpKitCore/Layout/HwpTextAttributeCache.swift
@@ -33,9 +33,27 @@ import Foundation
 /// 기존 init 그대로다.
 final class HwpTextAttributeCache: @unchecked Sendable {
     private struct AttributeKey: Hashable {
-        let shapeId: UInt32
+        /// `nil` = `index`에 없는 글자 모양 id. `HwpTextRunBuilder.resolvedShape`의
+        /// 폴백이 문단과 무관한 상수 (`HwpCharShape()`)라 미해결 id는 결과 사전이
+        /// 전부 같으므로 **한 키로 접는다**. 접지 않으면 조작 문서가 문자마다 다른
+        /// id를 흘려 내용이 같은 항목을 문서 수명 내내 쌓게 된다.
+        let shapeId: UInt32?
         let script: HwpScript
     }
+
+    /// 저장소별 항목 수 상한 — 넘으면 **축출이 아니라 삽입 중단**이다. 조판은 문서를
+    /// 순서대로 훑으므로 FIFO 축출은 워킹셋이 상한보다 클 때 히트율 0% + 매번 전량
+    /// 재삽입이 된다 (`HwpPageLayer` 줄 배치 캐시에서 겪은 함정). 미스가 `create`
+    /// 폴백이라 삽입을 멈춰도 결과는 같다 — 느려질 뿐이다.
+    ///
+    /// 정상 문서는 닿지 않는다: 미해결 id가 위에서 한 키로 접히므로 항목 수는
+    /// (문서가 실제 가진 charShape 수) × (스크립트 7) 이하이고, 상한에 닿으려면
+    /// 9,000개 넘는 글자 모양을 실제로 쓰는 문서여야 한다. 항목당 수백 바이트라
+    /// 상한 자체도 수십 MB 수준 — `HwpPaginator.maximumDocumentPages`와 같은 결의 절단.
+    static let maximumStoredEntries = 65536
+    /// 인스턴스 상한 (기본 = 전역) — 테스트가 상한 경로를 작은 입력으로 재현한다
+    /// (`HwpPageLayer.cachedLineBudget`와 같은 패턴).
+    var maximumEntries = HwpTextAttributeCache.maximumStoredEntries
 
     /// 사전과 그 값 (CTFont/CGColor/NSNumber)은 모두 불변으로 다룬다 (위 계약) —
     /// 저장소 접근만 lock으로 감싼다. `HwpFontResolver.FontCache`와 같은 패턴.
@@ -62,13 +80,19 @@ final class HwpTextAttributeCache: @unchecked Sendable {
         return misses
     }
 
+    var entryCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return attributeStorage.count
+    }
+
     /// `(shapeId, script)`의 텍스트 속성 사전. 없으면 `create`로 만들어 채운다.
     ///
     /// `create`는 lock 밖에서 부른다 — CoreText 폰트 생성이 무거워 lock을 쥔 채
     /// 부르면 병렬 조판이 직렬화된다. 경합하면 같은 키를 두 번 만들 수 있지만 순수
     /// 함수라 결과가 같다 (`FontCache`와 같은 절충).
     func attributes(
-        shapeId: UInt32,
+        shapeId: UInt32?,
         script: HwpScript,
         create: () -> [NSAttributedString.Key: Any]
     ) -> [NSAttributedString.Key: Any] {
@@ -83,7 +107,9 @@ final class HwpTextAttributeCache: @unchecked Sendable {
         lock.unlock()
         let attributes = create()
         lock.lock()
-        attributeStorage[key] = attributes
+        if attributeStorage.count < maximumEntries {
+            attributeStorage[key] = attributes
+        }
         lock.unlock()
         return attributes
     }
@@ -101,7 +127,9 @@ final class HwpTextAttributeCache: @unchecked Sendable {
         lock.unlock()
         let tabs = index.textTabs(for: paraShape)
         lock.lock()
-        tabStorage[key] = tabs
+        if tabStorage.count < maximumEntries {
+            tabStorage[key] = tabs
+        }
         lock.unlock()
         return tabs
     }

--- a/Sources/HwpKitCore/Layout/HwpTextRunBuilder.swift
+++ b/Sources/HwpKitCore/Layout/HwpTextRunBuilder.swift
@@ -54,15 +54,33 @@ public struct HwpTextRunBuilder {
     /// 상대 크기 기준 해석기 — treatAsChar 개체의 줄 공간 예약이 paint 쪽
     /// (HwpPaginator.objectSize)과 같은 크기를 쓰게 한다. 없으면 절대값 해석.
     let sizeResolver: HwpObjectSizeResolver?
+    /// 글자 모양별 속성 사전 캐시 — 같은 문서(`index`)·같은 `fontResolver`를 쓰는
+    /// 빌더끼리 공유한다 (소유는 `HwpPaginator`). nil이면 매번 새로 계산한다.
+    let attributeCache: HwpTextAttributeCache?
 
     public init(
         index: HwpIndex,
         fontResolver: HwpFontResolver,
         sizeResolver: HwpObjectSizeResolver? = nil
     ) {
+        self.init(
+            index: index, fontResolver: fontResolver,
+            sizeResolver: sizeResolver, attributeCache: nil
+        )
+    }
+
+    /// 캐시를 주입하는 모듈 내부용 init — 캐시는 문서 단위 소유라 모듈 밖으로
+    /// 열지 않는다 (`HwpTextAttributeCache` 참조).
+    init(
+        index: HwpIndex,
+        fontResolver: HwpFontResolver,
+        sizeResolver: HwpObjectSizeResolver? = nil,
+        attributeCache: HwpTextAttributeCache?
+    ) {
         self.index = index
         self.fontResolver = fontResolver
         self.sizeResolver = sizeResolver
+        self.attributeCache = attributeCache
     }
 
     /// controlReplacements: extended 컨트롤 ordinal (controlIndex) → 마커 대신
@@ -239,7 +257,8 @@ extension HwpTextRunBuilder {
             value: HwpParagraphLayout.paragraphStyle(
                 for: paraShape,
                 attributedString: output,
-                tabStops: index.textTabs(for: paraShape)
+                tabStops: attributeCache?.textTabs(for: paraShape, index: index)
+                    ?? index.textTabs(for: paraShape)
             ),
             range: NSRange(location: 0, length: output.length)
         )
@@ -353,7 +372,9 @@ extension HwpTextRunBuilder {
     ) {
         guard !chunk.text.isEmpty, let script = chunk.script else { return }
         let shape = resolvedShape(id: chunk.shapeId, paragraph: paragraph)
-        var chunkAttributes = attributes(for: shape, script: script)
+        var chunkAttributes = attributes(
+            forShapeId: chunk.shapeId, shape: shape, script: script
+        )
         applyTrackChangeMark(chunk.trackMark, to: &chunkAttributes)
         if chunk.memoAnchor,
            chunkAttributes[HwpAttributedStringKey.shadeColor] == nil
@@ -395,7 +416,7 @@ extension HwpTextRunBuilder {
         if inlineValue == 9 {
             output.append(NSAttributedString(
                 string: "\t",
-                attributes: attributes(for: shape, script: .english)
+                attributes: attributes(forShapeId: shapeId, shape: shape, script: .english)
             ))
             return
         }
@@ -403,7 +424,9 @@ extension HwpTextRunBuilder {
         // 치환 텍스트가 있으면 마커 대신 실제 번호 run을 방출한다.
         if let replacement, !replacement.text.isEmpty {
             let script = detectScript(in: replacement.text)
-            var textAttributes = attributes(for: shape, script: script)
+            var textAttributes = attributes(
+                forShapeId: shapeId, shape: shape, script: script
+            )
             if replacement.isSuperscript {
                 applySuperscript(to: &textAttributes, shape: shape)
             }
@@ -419,7 +442,9 @@ extension HwpTextRunBuilder {
             return
         }
 
-        var markerAttributes = attributes(for: shape, script: .english)
+        // 마커 전용 값 (controlIndex·inlineObjectHeight·run delegate)은 캐시된 사전의
+        // 사본에만 붙는다 — 개체 크기가 controlIndex마다 다르므로 캐시에 넣으면 안 된다.
+        var markerAttributes = attributes(forShapeId: shapeId, shape: shape, script: .english)
         var size = CGSize.zero
         if let controlIndex {
             markerAttributes[HwpAttributedStringKey.controlIndex] = NSNumber(value: controlIndex)
@@ -440,6 +465,22 @@ extension HwpTextRunBuilder {
             markerAttributes[kCTRunDelegateAttributeName as NSAttributedString.Key] = delegate
         }
         output.append(NSAttributedString(string: "\u{FFFC}", attributes: markerAttributes))
+    }
+
+    /// 캐시를 거친 `attributes(for:script:)`. `shape`는 `resolvedShape(id:paragraph:)`가
+    /// `shapeId`로 만든 것이어야 한다 — 키가 id뿐이라 다른 shape를 넘기면 오염된다.
+    ///
+    /// 돌려받은 사전은 **제자리에서 변형하지 말 것** (`HwpTextAttributeCache` 계약):
+    /// 호출부는 `var` 사본에 키를 추가·치환만 한다.
+    func attributes(
+        forShapeId shapeId: UInt32,
+        shape: CoreHwp.HwpCharShape,
+        script: HwpScript
+    ) -> [NSAttributedString.Key: Any] {
+        guard let attributeCache else { return attributes(for: shape, script: script) }
+        return attributeCache.attributes(shapeId: shapeId, script: script) {
+            attributes(for: shape, script: script)
+        }
     }
 
     func attributes(

--- a/Sources/HwpKitCore/Layout/HwpTextRunBuilder.swift
+++ b/Sources/HwpKitCore/Layout/HwpTextRunBuilder.swift
@@ -371,10 +371,8 @@ extension HwpTextRunBuilder {
         to output: NSMutableAttributedString
     ) {
         guard !chunk.text.isEmpty, let script = chunk.script else { return }
-        let shape = resolvedShape(id: chunk.shapeId, paragraph: paragraph)
-        var chunkAttributes = attributes(
-            forShapeId: chunk.shapeId, shape: shape, script: script
-        )
+        let resolved = resolvedShape(id: chunk.shapeId, paragraph: paragraph)
+        var chunkAttributes = attributes(for: resolved, script: script)
         applyTrackChangeMark(chunk.trackMark, to: &chunkAttributes)
         if chunk.memoAnchor,
            chunkAttributes[HwpAttributedStringKey.shadeColor] == nil
@@ -389,7 +387,7 @@ extension HwpTextRunBuilder {
             string: chunk.text,
             attributes: chunkAttributes
         )
-        if !shape.property.doesAdjustBlank, !index.isCompatibilityDocument {
+        if !resolved.shape.property.doesAdjustBlank, !index.isCompatibilityDocument {
             // 워드 호환 문서 (표 20)는 폰트 고유 공백 — 한글 문서만 0.5em
             Self.applyFixedSpaceWidth(to: attributed)
         }
@@ -410,13 +408,13 @@ extension HwpTextRunBuilder {
         inlineValue: CoreHwp.WCHAR? = nil,
         to output: NSMutableAttributedString
     ) {
-        let shape = resolvedShape(id: shapeId, paragraph: paragraph)
+        let resolved = resolvedShape(id: shapeId, paragraph: paragraph)
 
         // 탭 (inline 코드 9)은 실제 탭으로 방출한다 (CT 탭 스톱 조판).
         if inlineValue == 9 {
             output.append(NSAttributedString(
                 string: "\t",
-                attributes: attributes(forShapeId: shapeId, shape: shape, script: .english)
+                attributes: attributes(for: resolved, script: .english)
             ))
             return
         }
@@ -424,11 +422,9 @@ extension HwpTextRunBuilder {
         // 치환 텍스트가 있으면 마커 대신 실제 번호 run을 방출한다.
         if let replacement, !replacement.text.isEmpty {
             let script = detectScript(in: replacement.text)
-            var textAttributes = attributes(
-                forShapeId: shapeId, shape: shape, script: script
-            )
+            var textAttributes = attributes(for: resolved, script: script)
             if replacement.isSuperscript {
-                applySuperscript(to: &textAttributes, shape: shape)
+                applySuperscript(to: &textAttributes, shape: resolved.shape)
             }
             if let controlIndex {
                 textAttributes[HwpAttributedStringKey.controlIndex] = NSNumber(
@@ -444,7 +440,7 @@ extension HwpTextRunBuilder {
 
         // 마커 전용 값 (controlIndex·inlineObjectHeight·run delegate)은 캐시된 사전의
         // 사본에만 붙는다 — 개체 크기가 controlIndex마다 다르므로 캐시에 넣으면 안 된다.
-        var markerAttributes = attributes(forShapeId: shapeId, shape: shape, script: .english)
+        var markerAttributes = attributes(for: resolved, script: .english)
         var size = CGSize.zero
         if let controlIndex {
             markerAttributes[HwpAttributedStringKey.controlIndex] = NSNumber(value: controlIndex)
@@ -467,19 +463,20 @@ extension HwpTextRunBuilder {
         output.append(NSAttributedString(string: "\u{FFFC}", attributes: markerAttributes))
     }
 
-    /// 캐시를 거친 `attributes(for:script:)`. `shape`는 `resolvedShape(id:paragraph:)`가
-    /// `shapeId`로 만든 것이어야 한다 — 키가 id뿐이라 다른 shape를 넘기면 오염된다.
+    /// 캐시를 거친 `attributes(for:script:)`.
+    ///
+    /// `ResolvedShape`만 받으므로 캐시 키와 실제 shape가 어긋난 짝을 넘길 길이 없다
+    /// (키에 shape 내용이 없어 어긋나면 조용히 오염된다).
     ///
     /// 돌려받은 사전은 **제자리에서 변형하지 말 것** (`HwpTextAttributeCache` 계약):
     /// 호출부는 `var` 사본에 키를 추가·치환만 한다.
     func attributes(
-        forShapeId shapeId: UInt32,
-        shape: CoreHwp.HwpCharShape,
+        for resolved: ResolvedShape,
         script: HwpScript
     ) -> [NSAttributedString.Key: Any] {
-        guard let attributeCache else { return attributes(for: shape, script: script) }
-        return attributeCache.attributes(shapeId: shapeId, script: script) {
-            attributes(for: shape, script: script)
+        guard let attributeCache else { return attributes(for: resolved.shape, script: script) }
+        return attributeCache.attributes(shapeId: resolved.cacheKey, script: script) {
+            attributes(for: resolved.shape, script: script)
         }
     }
 
@@ -546,9 +543,19 @@ extension HwpTextRunBuilder {
         return attributes
     }
 
-    func resolvedShape(id: UInt32, paragraph: CoreHwp.HwpParagraph) -> CoreHwp.HwpCharShape {
+    /// 해석된 글자 모양과 그 캐시 키를 한 값으로 묶는다 — 짝이 어긋난 조합을
+    /// `attributes(for:script:)`에 넘길 수 없게 하기 위해서다.
+    ///
+    /// `cacheKey`가 nil이면 `index`에 없는 id라 아래 폴백 상수를 쓴 것이다. 그런
+    /// id는 결과 사전이 전부 같으므로 캐시에서 한 키로 접힌다.
+    struct ResolvedShape {
+        let shape: CoreHwp.HwpCharShape
+        let cacheKey: UInt32?
+    }
+
+    func resolvedShape(id: UInt32, paragraph: CoreHwp.HwpParagraph) -> ResolvedShape {
         if let shape = index.charShape(id: id) {
-            return shape
+            return ResolvedShape(shape: shape, cacheKey: id)
         }
         os_log(
             "HwpTextRunBuilder missing char shape: paraId=%{public}u shapeId=%{public}u",
@@ -556,7 +563,7 @@ extension HwpTextRunBuilder {
             paragraph.paraHeader.paraId,
             id
         )
-        return CoreHwp.HwpCharShape()
+        return ResolvedShape(shape: CoreHwp.HwpCharShape(), cacheKey: nil)
     }
 
     func activeShapeId(at position: UInt32, in paraCharShape: CoreHwp.HwpParaCharShape) -> UInt32 {

--- a/Sources/HwpKitCore/Layout/HwpTextRunBuilderFontFallback.swift
+++ b/Sources/HwpKitCore/Layout/HwpTextRunBuilderFontFallback.swift
@@ -57,7 +57,7 @@ extension HwpTextRunBuilder {
         // 글머리표 기호 (□ 등)는 한글 폰트의 전각 글리프로 그린다 —
         // 라틴 폴백 폰트의 기호는 실물보다 작다 (noori 라운드 11 실측:
         // 실물 □ = 글자 높이의 84%, 폴백은 53%)
-        var bulletAttributes = attributes(for: shape, script: .korean)
+        var bulletAttributes = attributes(forShapeId: shapeId, shape: shape, script: .korean)
         let isGeometricShape = bullet.char.unicodeScalars
             .allSatisfy { (0x25A0 ... 0x25FF).contains($0.value) }
         if isGeometricShape,

--- a/Sources/HwpKitCore/Layout/HwpTextRunBuilderFontFallback.swift
+++ b/Sources/HwpKitCore/Layout/HwpTextRunBuilderFontFallback.swift
@@ -53,11 +53,11 @@ extension HwpTextRunBuilder {
               !bullet.char.isEmpty
         else { return }
         let shapeId = activeShapeId(at: 0, in: paragraph.paraCharShape)
-        let shape = resolvedShape(id: shapeId, paragraph: paragraph)
+        let resolved = resolvedShape(id: shapeId, paragraph: paragraph)
         // 글머리표 기호 (□ 등)는 한글 폰트의 전각 글리프로 그린다 —
         // 라틴 폴백 폰트의 기호는 실물보다 작다 (noori 라운드 11 실측:
         // 실물 □ = 글자 높이의 84%, 폴백은 53%)
-        var bulletAttributes = attributes(forShapeId: shapeId, shape: shape, script: .korean)
+        var bulletAttributes = attributes(for: resolved, script: .korean)
         let isGeometricShape = bullet.char.unicodeScalars
             .allSatisfy { (0x25A0 ... 0x25FF).contains($0.value) }
         if isGeometricShape,

--- a/Sources/HwpKitCore/Layout/HwpTextboxLayout.swift
+++ b/Sources/HwpKitCore/Layout/HwpTextboxLayout.swift
@@ -41,9 +41,17 @@ public struct HwpTextboxFrame: @unchecked Sendable, Hashable {
 
 public struct HwpTextboxLayout {
     private let fontResolver: HwpFontResolver
+    /// 글상자 문단이 본문과 같은 글자 모양 속성 캐시를 쓰게 한다 (소유는 `HwpPaginator`).
+    private let attributeCache: HwpTextAttributeCache?
 
     public init(fontResolver: HwpFontResolver = HwpFontResolver()) {
+        self.init(fontResolver: fontResolver, attributeCache: nil)
+    }
+
+    /// 캐시를 주입하는 모듈 내부용 init (`HwpTextAttributeCache` 참조).
+    init(fontResolver: HwpFontResolver, attributeCache: HwpTextAttributeCache?) {
         self.fontResolver = fontResolver
+        self.attributeCache = attributeCache
     }
 
     /// gso 컨트롤의 글상자를 레이아웃한다.
@@ -147,13 +155,15 @@ public struct HwpTextboxLayout {
         let measurer = HwpParagraphMeasurer(
             index: index,
             fontResolver: fontResolver,
-            sizeResolver: boxResolver
+            sizeResolver: boxResolver,
+            attributeCache: attributeCache
         )
         let collector = HwpParagraphObjectCollector(
             index: index,
             fontResolver: fontResolver,
             sizeResolver: boxResolver,
-            collectsTextboxes: false
+            collectsTextboxes: false,
+            attributeCache: attributeCache
         )
         var contents = LaidOutTextboxContents()
         var contentY = insets.top

--- a/Sources/HwpKitCore/Layout/Paginator/HwpFootnoteCoordinator.swift
+++ b/Sources/HwpKitCore/Layout/Paginator/HwpFootnoteCoordinator.swift
@@ -29,6 +29,8 @@ struct HwpFootnoteCoordinator {
 
     private let index: HwpIndex
     private let fontResolver: HwpFontResolver
+    /// 글자 모양별 속성 캐시 (소유는 `HwpPaginator`) — 각주 측정도 본문과 공유한다.
+    private let attributeCache: HwpTextAttributeCache?
     private let footnoteLayout: HwpFootnoteLayout
 
     /// 이 페이지에 배치할 각주 (문단 + 문서 순서 번호)
@@ -44,10 +46,17 @@ struct HwpFootnoteCoordinator {
     /// 같은 각주를 반복 CT 레이아웃하지 않게 한다.
     private var footnoteHeightCache: [FootnoteHeightKey: CGFloat] = [:]
 
-    init(index: HwpIndex, fontResolver: HwpFontResolver) {
+    init(
+        index: HwpIndex,
+        fontResolver: HwpFontResolver,
+        attributeCache: HwpTextAttributeCache? = nil
+    ) {
         self.index = index
         self.fontResolver = fontResolver
-        footnoteLayout = HwpFootnoteLayout(fontResolver: fontResolver)
+        self.attributeCache = attributeCache
+        footnoteLayout = HwpFootnoteLayout(
+            fontResolver: fontResolver, attributeCache: attributeCache
+        )
     }
 
     // MARK: 수집
@@ -323,16 +332,18 @@ struct HwpFootnoteCoordinator {
             return cached
         }
 
-        let measured = HwpParagraphMeasurer(index: index, fontResolver: fontResolver)
-            .measure(
-                paragraph,
-                width: width,
-                options: .init(controlReplacements: HwpTextRunBuilder.autoNumberReplacements(
-                    in: paragraph,
-                    number: number,
-                    footnoteShape: environment.footnoteShape
-                ))
-            )
+        let measured = HwpParagraphMeasurer(
+            index: index, fontResolver: fontResolver, attributeCache: attributeCache
+        )
+        .measure(
+            paragraph,
+            width: width,
+            options: .init(controlReplacements: HwpTextRunBuilder.autoNumberReplacements(
+                in: paragraph,
+                number: number,
+                footnoteShape: environment.footnoteShape
+            ))
+        )
         let height = max(1, measured.frame.totalHeight)
         footnoteHeightCache[key] = height
         return height

--- a/Sources/HwpKitCore/Layout/Paginator/HwpPageChromeBuilder.swift
+++ b/Sources/HwpKitCore/Layout/Paginator/HwpPageChromeBuilder.swift
@@ -39,11 +39,19 @@ struct HwpPageChromeBuilder {
 
     private let index: HwpIndex
     private let fontResolver: HwpFontResolver
+    /// 글자 모양별 속성 캐시 (소유는 `HwpPaginator`) — 머리말/꼬리말 문단도
+    /// 본문과 같은 캐시를 쓴다.
+    private let attributeCache: HwpTextAttributeCache?
     private var state = State()
 
-    init(index: HwpIndex, fontResolver: HwpFontResolver) {
+    init(
+        index: HwpIndex,
+        fontResolver: HwpFontResolver,
+        attributeCache: HwpTextAttributeCache? = nil
+    ) {
         self.index = index
         self.fontResolver = fontResolver
+        self.attributeCache = attributeCache
     }
 
     // MARK: 컨트롤 등록
@@ -211,7 +219,9 @@ struct HwpPageChromeBuilder {
         bandFrame: CGRect,
         pageNumber: Int
     ) -> [AnyHwpBlock] {
-        let builder = HwpTextRunBuilder(index: index, fontResolver: fontResolver)
+        let builder = HwpTextRunBuilder(
+            index: index, fontResolver: fontResolver, attributeCache: attributeCache
+        )
         let paragraphLayout = HwpParagraphLayout()
         var cursorY = bandFrame.minY
         var blocks: [AnyHwpBlock] = []
@@ -240,7 +250,8 @@ struct HwpPageChromeBuilder {
                 attributedString: attributed,
                 paraShape: paraShape,
                 columnWidth: bandFrame.width,
-                tabStops: index.textTabs(for: paraShape)
+                tabStops: attributeCache?.textTabs(for: paraShape, index: index)
+                    ?? index.textTabs(for: paraShape)
             )
             let blockHeight = max(1, frame.totalHeight)
             blocks.append(AnyHwpBlock(

--- a/Sources/HwpKitNative/AGENTS.md
+++ b/Sources/HwpKitNative/AGENTS.md
@@ -63,6 +63,7 @@ macOS 페이지 레이어는 `HwpFlippedContentView` (isFlipped=true, NSScrollVi
 - **상한 초과 시 축출이 아니라 삽입 중단**이다. draw 는 커맨드를 항상 같은 순서로 전량 훑으므로 FIFO 축출은 워킹셋이 상한보다 큰 페이지에서 히트율 0% + 매 draw 전량 재삽입이 된다. 상한은 엔트리 수가 아니라 누적 줄 수 (`cachedLineBudget` 기본 8,192 — 엔트리 하나가 `maximumLineFrames` = 100,000 줄까지 담을 수 있어 엔트리 수 상한은 CTLine 보유량을 못 묶는다). 인스턴스 프로퍼티라 테스트가 값을 낮춰 초과 경로를 작은 문서로 재현한다.
 - **락 (`NSLock`) 은 딕셔너리 조회/저장 순간에만 잡는다** — CoreText 조판·CTLineDraw 중에는 보유 금지 (그 아래로 텍스트 호출이 추가돼도 재진입 데드락이 없게). `paintList` didSet 의 `setNeedsDisplay()` 도 락 밖이다. 이 락은 Dictionary 동시 변형이라는 메모리 비안전만 막을 뿐 레이어를 thread-safe 하게 만들지 않는다 (클래스가 `@unchecked Sendable`).
 - 텍스트 선택의 `HwpSelectionGeometry` 도 같은 `[HwpDrawnLine]` 을 캐시하지만 **문서 스코프 + FIFO 512** 로 별개다 (그쪽은 랜덤 액세스라 FIFO 가 맞는다). 두 캐시는 서로 독립이다.
+- HwpKitCore 의 `HwpTextAttributeCache` 와는 **층**이 다르다 — 그쪽은 문서 빌드 (paginate) 때 `NSAttributedString` 을 만드는 **입력** (글자 모양별 속성 사전) 을 메모하고, 이 캐시는 그 결과 문자열의 **draw 때 조판**을 메모한다. 서로 참조하지 않고 이득도 겹치지 않으므로 (단계가 다르다) 하나가 있다고 다른 하나가 불필요해지지 않는다.
 - 회귀 가드는 `Tests/HwpKitNativeTests/HwpPageLayerCacheTests.swift` (7종). **기존 뷰 테스트는 전부 draw 1회라 콜드 경로만 타서 캐시 버그를 잡지 못한다** — 캐시를 건드리면 draw 를 2회 이상 돌리고 `typesetCount` / `cachedDrawnLineEntryCount` (테스트 전용 관측점) 로 단언할 것.
 - 실측 (macOS, 재드로 20회, 캐시 무력화 A/B): Column 1쪽 681.0 → 368.9ms (1.85x, 조판 220 → 0회), noori 3쪽 913.9 → 596.4ms (1.53x, 1360 → 80회 — 잔여 80 = 플레이스홀더 4개 × 20회로 설계대로 우회). 남는 시간은 CTLineDraw·장식이라 캐시가 줄일 몫이 아니고, 레이어가 객체째 폐기·재생성되는 스크롤은 콜드 경로라 이득이 없다.
 

--- a/Tests/HwpKitCoreTests/HwpTextRunBuilderTests.swift
+++ b/Tests/HwpKitCoreTests/HwpTextRunBuilderTests.swift
@@ -266,11 +266,127 @@ import XCTest
             let whole = runBuilder.build(paragraph: paragraph, maxCharacters: 4)
             expect(whole.string) == "ab😀"
         }
+
+        // MARK: 글자 모양 속성 캐시 (HwpTextAttributeCache)
+
+        func testAttributeCacheProducesIdenticalAttributedString() throws {
+            // 순수 성능 캐시 — 결과가 1비트도 달라지면 안 된다. 장평·볼드·이탤릭·
+            // 장식이 붙은 모양과 스크립트가 섞인 문단으로 파생 경로를 모두 태운다.
+            let shapes = try decoratedShapes()
+            let paragraph = paragraph(text: "가나daま?", runs: [(0, 0), (2, 1), (4, 2)])
+            let cache = HwpTextAttributeCache()
+
+            let cached = builder(shapes: shapes, cache: cache).build(paragraph: paragraph)
+            let uncached = builder(shapes: shapes, cache: nil).build(paragraph: paragraph)
+
+            expect(cached.isEqual(to: uncached)) == true
+            // 2회차도 (전부 캐시 히트) 같아야 한다.
+            let again = builder(shapes: shapes, cache: cache).build(paragraph: paragraph)
+            expect(again.isEqual(to: uncached)) == true
+        }
+
+        func testAttributeCacheReusesEntriesAcrossBuilders() throws {
+            // 같은 캐시를 공유하는 빌더끼리 (본문/표 셀/각주) 재계산이 사라진다.
+            let shapes = [UInt32(0): try charShape()]
+            let paragraph = paragraph(text: "가나", runs: [(0, 0)])
+            let cache = HwpTextAttributeCache()
+
+            _ = builder(shapes: shapes, cache: cache).build(paragraph: paragraph)
+            expect(cache.missCount) == 1
+            expect(cache.hitCount) == 0
+
+            _ = builder(shapes: shapes, cache: cache).build(paragraph: paragraph)
+            expect(cache.missCount) == 1
+            expect(cache.hitCount) == 1
+        }
+
+        func testAttributeCacheKeysOnScriptAsWellAsShape() throws {
+            // 같은 글자 모양이라도 스크립트마다 face/크기 슬롯이 다르다 — 키에
+            // script가 빠지면 한글 run이 라틴 폰트로 그려진다.
+            let shapes = [UInt32(0): try charShape()]
+            let cache = HwpTextAttributeCache()
+
+            _ = builder(shapes: shapes, cache: cache)
+                .build(paragraph: paragraph(text: "가a", runs: [(0, 0)]))
+
+            expect(cache.missCount) == 2
+            expect(cache.hitCount) == 0
+        }
+
+        func testAttributeCacheIsNotPollutedByPerRunTrackChangeMark() throws {
+            // 변경추적 표시는 반환된 사전의 사본에만 붙는다 — 캐시 항목을 제자리에서
+            // 바꾸면 같은 글자 모양의 비-추적 run까지 빨갛게 물든다.
+            var tracked = paragraph(text: "가나다라", runs: [(0, 0)])
+            tracked.paraRangeTagArray = [try rangeTag(start: 0, end: 2, kind: 16)]
+            let shapes = [UInt32(0): try charShape()]
+
+            let result = builder(shapes: shapes, cache: HwpTextAttributeCache())
+                .build(paragraph: tracked)
+
+            let colorKey = kCTForegroundColorAttributeName as NSAttributedString.Key
+            let marked = result.attributes(at: 0, effectiveRange: nil)[colorKey]
+            let plain = result.attributes(at: 2, effectiveRange: nil)[colorKey]
+            let expected = builder(shapes: shapes, cache: nil)
+                .build(paragraph: paragraph(text: "가나다라", runs: [(0, 0)]))
+                .attributes(at: 0, effectiveRange: nil)[colorKey]
+
+            expect(CFEqual(marked as CFTypeRef, plain as CFTypeRef)) == false
+            expect(CFEqual(plain as CFTypeRef, expected as CFTypeRef)) == true
+        }
+
+        func testAttributeCacheReusesTabStopsPerTabDefinition() {
+            // CTTextTab은 불변이고 tabDefId만의 함수라 문서 안에서 공유한다.
+            let cache = HwpTextAttributeCache()
+            let paraShape = CoreHwp.HwpParaShape()
+            let documentIndex = index(shapes: [:])
+
+            let first = cache.textTabs(for: paraShape, index: documentIndex)
+            let second = cache.textTabs(for: paraShape, index: documentIndex)
+
+            expect(first.count) == documentIndex.textTabs(for: paraShape).count
+            expect(second.count) == first.count
+        }
     }
 
     private extension HwpTextRunBuilderTests {
         func builder(shapes: [UInt32: CoreHwp.HwpCharShape]) -> HwpTextRunBuilder {
             HwpTextRunBuilder(index: index(shapes: shapes), fontResolver: .testDeterministic)
+        }
+
+        /// 캐시를 공유하는 빌더 — 캐시가 문서 단위 소유라는 계약대로, 같은 내용의
+        /// `index`를 쓰는 빌더끼리만 하나를 나눠 쓴다.
+        func builder(
+            shapes: [UInt32: CoreHwp.HwpCharShape],
+            cache: HwpTextAttributeCache?
+        ) -> HwpTextRunBuilder {
+            HwpTextRunBuilder(
+                index: index(shapes: shapes),
+                fontResolver: .testDeterministic,
+                attributeCache: cache
+            )
+        }
+
+        /// 장평·볼드·이탤릭·밑줄·그림자가 붙은 모양 3종 (파생 CTFont 경로 전수)
+        func decoratedShapes() throws -> [UInt32: CoreHwp.HwpCharShape] {
+            [
+                0: try charShape(),
+                // 표 33 property: bit 0 이탤릭 / bit 1 진하게 / bits 2-4 밑줄 종류
+                1: try charShape(property: 0b111, faceScaleX: Array(repeating: 90, count: 7)),
+                2: try charShape(property: 0b10, faceScaleX: Array(repeating: 120, count: 7)),
+            ]
+        }
+
+        /// 변경추적 range tag (상위 8비트 = 종류, 16 삽입 / 17 삭제)
+        func rangeTag(
+            start: UInt32,
+            end: UInt32,
+            kind: UInt32
+        ) throws -> CoreHwp.HwpParaRangeTag {
+            var data = Data()
+            append(start, to: &data)
+            append(end, to: &data)
+            append(kind << 24, to: &data)
+            return try CoreHwp.HwpParaRangeTag.load(data)
         }
 
         func index(shapes: [UInt32: CoreHwp.HwpCharShape]) -> HwpIndex {

--- a/Tests/HwpKitCoreTests/HwpTextRunBuilderTests.swift
+++ b/Tests/HwpKitCoreTests/HwpTextRunBuilderTests.swift
@@ -346,6 +346,38 @@ import XCTest
             expect(first.count) == documentIndex.textTabs(for: paraShape).count
             expect(second.count) == first.count
         }
+
+        func testAttributeCacheFoldsUnresolvedShapeIdsIntoOneEntry() {
+            // index에 없는 id는 문단과 무관한 상수 폴백을 쓰므로 결과 사전이 전부
+            // 같다 — 원본 id로 키를 잡으면 조작 문서가 문자마다 다른 id를 흘려
+            // 내용이 같은 항목을 문서 수명 내내 쌓는다 (R41 P1 리뷰).
+            let cache = HwpTextAttributeCache()
+            let distinctUnresolved = (0 ..< 64).map { (UInt32($0), UInt32($0) &* 7 &+ 1) }
+            let paragraph = paragraph(
+                text: String(repeating: "가", count: 64), runs: distinctUnresolved
+            )
+
+            _ = builder(shapes: [:], cache: cache).build(paragraph: paragraph)
+
+            expect(cache.entryCount) == 1
+            expect(cache.missCount) == 1
+            expect(cache.hitCount) == 63
+        }
+
+        func testAttributeCacheStopsInsertingBeyondEntryLimit() throws {
+            // 상한 초과는 축출이 아니라 삽입 중단 — 미스가 create 폴백이라
+            // 결과는 그대로여야 한다 (느려질 뿐).
+            let shapes = try decoratedShapes()
+            let paragraph = paragraph(text: "가나다", runs: [(0, 0), (1, 1), (2, 2)])
+            let cache = HwpTextAttributeCache()
+            cache.maximumEntries = 2
+
+            let capped = builder(shapes: shapes, cache: cache).build(paragraph: paragraph)
+            let uncached = builder(shapes: shapes, cache: nil).build(paragraph: paragraph)
+
+            expect(cache.entryCount) == 2
+            expect(capped.isEqual(to: uncached)) == true
+        }
     }
 
     private extension HwpTextRunBuilderTests {


### PR DESCRIPTION
Closes #71

## 요약

`HwpTextRunBuilder`는 같은 글자 모양과 스크립트의 텍스트 조각마다 속성 사전과 파생 `CTFont`를 다시 만들고 있었다. 문서 하나가 사용하는 글자 모양은 보통 수십 개이므로, 다음 두 결과를 문서 단위로 재사용하도록 `HwpTextAttributeCache`를 추가했다.

- `(shapeId: UInt32?, script)` → 텍스트 속성 사전
- `tabDefId` → `[CTTextTab]`

캐시는 `HwpPaginator`가 하나만 소유하며 본문·표 셀·글상자·각주·머리말/꼬리말·메모가 공유한다. 컨테이너 안 글상자가 별도 `HwpTextboxLayout`을 만드는 `HwpParagraphObjectCollector` 경로까지 전달했다.

같은 로컬 macOS 환경에서 캐시를 무력화한 before와 활성화한 after를 3회 측정한 중앙값은 다음과 같다.

| 대상 | before | after | 개선 |
|---|---:|---:|---:|
| `HWP_PERF=1 swift test --filter Performance` (N=20,000, 589쪽) | 10.95s | 6.17s | **1.78x** |
| legacy 1,030쪽 전체 조판 (`HwpDocumentLoader.load`) | 26.37s | 18.53s | **1.42x** |

public API는 바뀌지 않았다. 기존 public init은 그대로 두고, 캐시 타입과 캐시를 받는 init은 모두 internal로 제한했다.

## 설계와 안전장치

### 캐시 키가 충분한 이유

`index`와 `fontResolver`가 고정이면 기본 텍스트 속성은 글자 모양과 스크립트만으로 결정된다. 장평, 이탤릭 근사 매트릭스, 라틴 세리프 폴백, 색과 장식이 모두 `HwpCharShape`에서 나온다.

문단이나 run마다 달라지는 값은 캐시 조회 후 사전의 값 타입 사본에 붙는다.

- 변경추적 표시와 메모 앵커
- `controlIndex`, `inlineObjectHeight`, run delegate
- 컨트롤 치환 텍스트의 위 첨자
- 글머리표 기호의 폰트 치환

캐시에 들어가는 `CTFont`, `CGColor`, `NSNumber`는 불변 값으로 취급한다. 따라서 호출부는 반환된 사전의 키를 추가하거나 교체할 수 있지만, 이후 가변 참조 타입을 속성 값으로 넣는다면 별도 복사 정책이 필요하다.

### 문서 단위 소유

전역 캐시나 `HwpFontResolver` 소유 캐시는 사용하지 않았다.

- 같은 `shapeId`라도 `HwpIndex`가 다르면 다른 글자 모양을 뜻한다.
- `usesInstalledHancomFonts`는 resolver별 설정이므로 한 프로세스에서 한컴 폰트 opt-in on/off가 함께 존재할 수 있다.

문서 경계를 키에 넣지 않은 만큼, `HwpPaginator`가 캐시 수명을 소유하고 하위 레이아웃에만 주입한다.

### 미해결 id와 저장 상한

`index`에 없는 글자 모양 id는 항상 기본 `HwpCharShape()`로 폴백한다. 서로 다른 미해결 id를 원본 값으로 캐시하면 내용이 같은 항목이 계속 쌓이므로, 캐시 키의 `shapeId`를 `nil` 하나로 접었다. `ResolvedShape`가 해석된 shape와 캐시 키를 한 값으로 묶어 잘못된 조합을 넘기지 못하게 한다.

속성 저장소와 탭 저장소에는 각각 65,536개 상한을 둔다. 상한에 도달하면 기존 항목을 축출하지 않고 새 항목의 저장만 중단한다. 조판이 문서를 순서대로 훑는 특성상 FIFO 축출은 큰 워킹셋에서 재계산과 재삽입만 반복할 수 있기 때문이다. 저장하지 않은 miss도 즉시 계산해 반환하므로 결과는 바뀌지 않는다.

### 동기화와 탭 캐시

`NSLock`은 저장소 조회와 저장에만 사용하고, CoreText 속성 생성은 lock 밖에서 수행한다. 같은 키의 miss가 경합하면 중복 계산될 수 있지만 결과가 같은 순수 계산이므로 정합성에는 영향이 없다.

탭 캐시의 키는 현재 `HwpIndex.textTabs(for:)`가 실제로 읽는 `tabDefId` 하나다. 이 함수가 향후 다른 `HwpParaShape` 필드를 사용하게 되면 키도 함께 확장해야 하며, 이 계약을 `Sources/HwpKitCore/AGENTS.md`에 기록했다.

## 검증

렌더 결과가 바뀌지 않는 성능 변경이므로 속도와 등가성을 따로 검증했다.

- `swift test`: 전체 기본 스위트 통과
- `FixtureRenderHashSnapshotTests`: 전 픽스처·전 페이지에서 변경 0건 (한컴 폰트 off/on 양 모드)
- `FixtureBlockLayoutSnapshotTests`, `FixturePreviewFidelityTests`: 양 폰트 모드 통과
- 로컬 iOS 빌드: `BUILD SUCCEEDED`
- `swiftformat --lint .`: 통과 (`0/540 files require formatting`)
- `swiftlint`: error 0. 이 PR에서 추가된 warning 1건은 `HwpTableLayoutFrames.swift` 함수가 50줄에서 52줄로 늘어난 `function_body_length`다.

GitHub CI의 7개 체크도 모두 통과했다.

- Lint
- macOS 테스트와 CoreHwp 95% 커버리지 게이트
- iOS Simulator 테스트
- Linux Swift 5.9 / 6.3 테스트
- `codecov/patch` / `codecov/project`

Codecov 기준으로 수정된 coverable line은 모두 테스트되었고, 프로젝트 커버리지는 91.90%에서 91.95%로 올랐다.

## 회귀 테스트

`HwpTextRunBuilderTests`는 14개에서 21개로 늘었으며, 캐시 관련 테스트 7개를 추가했다.

1. 캐시/무캐시 attributed string 동치
2. 빌더 간 재사용과 hit/miss 카운트
3. 같은 shape의 script별 키 분리
4. 변경추적 표시가 캐시를 오염시키지 않음
5. `tabDefId`별 탭 스톱 재사용
6. 미해결 id 64개가 한 항목으로 접힘 (miss 1, hit 63)
7. 상한 도달 후 삽입 중단과 결과 불변

`hitCount`, `missCount`, `entryCount`는 캐시가 조용히 무력화되는 회귀를 잡기 위한 테스트 전용 관측점이다.

## #89와의 관계

#89의 `HwpPageLayer` 캐시는 완성된 문자열의 **draw 시 줄 배치 결과**를 재사용한다. 이 PR은 문서를 paginate하면서 문자열을 만드는 **입력 속성**을 재사용한다. 파이프라인 단계와 수명이 달라 서로 참조하지 않으며, 하나가 다른 하나를 대체하지 않는다.

## 커밋

- `8144c67` `perf:` 캐시 본체, 주입 배관, 캐시 테스트 5종
- `b47c4de` `docs:` AGENTS.md 3종
- `db0c3d9` `fix:` 미해결 id 접기, 저장 상한, 테스트 2종

---
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>